### PR TITLE
Enhance starting pitcher metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Includes metadata for each game such as:
 ['game_pk', 'game_date', 'away_team', 'home_team', 'game_number', 'double_header', 'away_pitcher_ids', 'home_pitcher_ids', 'hp_umpire', '1b_umpire', '2b_umpire', '3b_umpire', 'weather', 'temp', 'wind', 'elevation', 'dayNight', 'first_pitch', 'scraped_timestamp']
 ```
 
-### `game_level_starting_pitchers`
+### `statcast_starting_pitchers`
 
-Aggregated per-game stats for starting pitchers only. Rows are filtered from `statcast_pitchers` using the first pitch of each team in a game and requiring at least 3 innings pitched or 50 total pitches.
+Aggregated per-game stats for verified starting pitchers. Rows come from `statcast_pitchers` but filtered to the first pitcher for each team in inning 1 and only kept when they throw at least 25 pitches (avoiding openers).
 
 ```text
-['game_pk', 'pitcher_id', 'pitching_team', 'opponent_team', 'innings_pitched', 'pitches', 'strikeouts', 'swinging_strike_rate', 'first_pitch_strike_rate', 'fastball_pct', 'fastball_then_breaking_rate']
+['game_pk', 'pitcher', 'pitching_team', 'opponent_team', 'total_pitches', 'csw_rate', 'whiff_rate', 'first_pitch_strike_rate', 'strikeouts', 'pitch_type_FF', ...]
 ```
 ### `game_level_batters_vs_starters`
 
@@ -63,7 +63,7 @@ Aggregated per-game batting stats for each team facing the opponent's starting p
 
 ### `game_level_matchup_stats`
 
-Joins `game_level_starting_pitchers` with `game_level_team_batting` so each row represents one pitcher/team matchup for a game. Contains all pitcher metrics along with the aggregated opponent batting features.
+Joins `statcast_starting_pitchers` with `game_level_team_batting` so each row represents one pitcher/team matchup for a game. Contains all pitcher metrics along with the aggregated opponent batting features.
 
 
 ## Pipeline Structure

--- a/src/config.py
+++ b/src/config.py
@@ -11,6 +11,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 MLB_BOXSCORES_TABLE = 'mlb_boxscores'
 STATCAST_PITCHERS_TABLE = 'statcast_pitchers'
 STATCAST_BATTERS_TABLE = 'statcast_batters'
+STATCAST_STARTING_PITCHERS_TABLE = 'statcast_starting_pitchers'
 
 
 # Team Mapping Columns 

--- a/src/data/create_pitcher_vs_team_stats.py
+++ b/src/data/create_pitcher_vs_team_stats.py
@@ -4,10 +4,14 @@ import sqlite3
 from pathlib import Path
 
 from src.utils import DBConnection, setup_logger
-from src.config import DBConfig, LogConfig
+from src.config import (
+    DBConfig,
+    LogConfig,
+    STATCAST_STARTING_PITCHERS_TABLE,
+)
 
 BATTERS_VS_STARTERS_TABLE = "game_level_batters_vs_starters"
-STARTERS_TABLE = "game_level_starting_pitchers"
+STARTERS_TABLE = STATCAST_STARTING_PITCHERS_TABLE
 TEAM_BATTING_TABLE = "game_level_team_batting"
 MATCHUP_TABLE = "game_level_matchup_stats"
 


### PR DESCRIPTION
## Summary
- document `statcast_starting_pitchers` table
- enrich starting pitcher aggregation with swing/contact and pitch-type metrics
- filter out openers using a 25-pitch threshold

## Testing
- `python -m py_compile $(git ls-files '*.py')`
