### PR TITLE
Add logging in starter table script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Joins `game_level_starting_pitchers` with `game_level_team_batting` so each row 
 * Pandas, NumPy (data processing)
 * LightGBM (modeling)
 
+### Logging
+
+Logs are written to the `logs/` directory using the helper in `src.utils`.
+`create_starting_pitcher_table.py` now reports how many potential starters were
+found and prints progress every 100 games to `logs/create_starting_pitcher_table.log`.
+
 ## Next Steps
 
 * Finalize feature aggregation logic

--- a/src/create_starting_pitcher_table.py
+++ b/src/create_starting_pitcher_table.py
@@ -8,20 +8,21 @@ import logging
 from typing import Dict
 
 from src.utils import DBConnection, setup_logger
-from src.config import DBConfig
+from src.config import DBConfig, LogConfig
 
 # --- Pitch Type Groups ---
-FASTBALL_TYPES = {
-    'FF', 'FA', 'FT', 'SI', 'F4', 'F2', 'FC', 'FS', 'SF', 'FO'
-}
-BREAKING_TYPES = {
-    'SL', 'CU', 'KC', 'SV', 'SC'
-}
-OFFSPEED_TYPES = {
-    'CH', 'FS', 'FO', 'KN', 'EP'
-}
+FASTBALL_TYPES = {"FF", "FA", "FT", "SI", "F4", "F2", "FC", "FS", "SF", "FO"}
+BREAKING_TYPES = {"SL", "CU", "KC", "SV", "SC"}
+OFFSPEED_TYPES = {"CH", "FS", "FO", "KN", "EP"}
 
-logger = setup_logger('create_starting_pitcher_table')
+logger = setup_logger(
+    "create_starting_pitcher_table",
+    LogConfig.LOG_DIR / "create_starting_pitcher_table.log",
+)
+
+# Log progress after this many games have been processed
+LOG_EVERY_N = 100
+
 
 def filter_starting_pitchers(conn) -> pd.DataFrame:
     """Return game_pk/pitcher combos likely representing true starters."""
@@ -33,77 +34,96 @@ def filter_starting_pitchers(conn) -> pd.DataFrame:
            AND COUNT(*) > 30
            AND MAX(inning) > 3
     """
-    return pd.read_sql_query(query, conn)
+    df = pd.read_sql_query(query, conn)
+    logger.info("Found %d potential starting pitcher rows", len(df))
+    return df
+
 
 def load_pitcher_game(conn, game_pk: int, pitcher: int) -> pd.DataFrame:
     """Load all pitch-level rows for a pitcher in one game."""
     q = "SELECT * FROM statcast_pitchers WHERE game_pk = ? AND pitcher = ?"
     return pd.read_sql_query(q, conn, params=(game_pk, pitcher))
 
+
 def compute_features(df: pd.DataFrame) -> Dict:
-    df = df.sort_values(['at_bat_number', 'pitch_number'])
+    df = df.sort_values(["at_bat_number", "pitch_number"])
     first_row = df.iloc[0]
-    if first_row['inning_topbot'] == 'Top':
-        team = first_row['home_team']
-        opp = first_row['away_team']
+    if first_row["inning_topbot"] == "Top":
+        team = first_row["home_team"]
+        opp = first_row["away_team"]
     else:
-        team = first_row['away_team']
-        opp = first_row['home_team']
+        team = first_row["away_team"]
+        opp = first_row["home_team"]
 
     pitches = len(df)
-    strike_events = df['events'].isin(['strikeout', 'strikeout_double_play'])
-    swinging = df['description'].str.contains('swinging_strike', na=False)
-    called = df['description'].eq('called_strike')
-    foul_tip = df['description'].eq('foul_tip')
+    strike_events = df["events"].isin(["strikeout", "strikeout_double_play"])
+    swinging = df["description"].str.contains("swinging_strike", na=False)
+    called = df["description"].eq("called_strike")
+    foul_tip = df["description"].eq("foul_tip")
 
-    first_pitch = df[df['pitch_number'] == 1]
-    first_pitch_strikes = first_pitch['type'].eq('S')
+    first_pitch = df[df["pitch_number"] == 1]
+    first_pitch_strikes = first_pitch["type"].eq("S")
 
-    fastball_mask = df['pitch_type'].isin(FASTBALL_TYPES)
-    breaking_mask = df['pitch_type'].isin(BREAKING_TYPES)
-    offspeed_mask = df['pitch_type'].isin(OFFSPEED_TYPES)
+    fastball_mask = df["pitch_type"].isin(FASTBALL_TYPES)
+    breaking_mask = df["pitch_type"].isin(BREAKING_TYPES)
+    offspeed_mask = df["pitch_type"].isin(OFFSPEED_TYPES)
 
-    types = df['pitch_type'].values
+    types = df["pitch_type"].values
     next_types = np.roll(types, -1)
-    fastball_then_break = (fastball_mask & np.isin(next_types, list(BREAKING_TYPES)))
+    fastball_then_break = fastball_mask & np.isin(next_types, list(BREAKING_TYPES))
 
     features = {
-        'game_pk': first_row['game_pk'],
-        'game_date': first_row['game_date'],
-        'pitcher_id': first_row['pitcher'],
-        'pitcher_hand': first_row['p_throws'],
-        'pitching_team': team,
-        'opponent_team': opp,
-        'pitches': pitches,
-        'innings_pitched': df['inning'].nunique(),
-        'batters_faced': df['batter'].nunique(),
-        'strikeouts': strike_events.sum(),
-        'swinging_strike_rate': swinging.mean(),
-        'first_pitch_strike_rate': first_pitch_strikes.mean() if len(first_pitch) else np.nan,
-        'csw_pct': ((called | swinging | foul_tip).mean()),
-        'fastball_pct': fastball_mask.mean(),
-        'offspeed_to_fastball_ratio': offspeed_mask.sum() / fastball_mask.sum() if fastball_mask.sum() else np.nan,
-        'fastball_then_breaking_rate': fastball_then_break[:-1].mean() if len(df) > 1 else np.nan,
-        'avg_release_speed': df['release_speed'].mean(),
-        'max_release_speed': df['release_speed'].max(),
-        'avg_spin_rate': df['release_spin_rate'].mean(),
-        'unique_pitch_types': df['pitch_type'].nunique(),
+        "game_pk": first_row["game_pk"],
+        "game_date": first_row["game_date"],
+        "pitcher_id": first_row["pitcher"],
+        "pitcher_hand": first_row["p_throws"],
+        "pitching_team": team,
+        "opponent_team": opp,
+        "pitches": pitches,
+        "innings_pitched": df["inning"].nunique(),
+        "batters_faced": df["batter"].nunique(),
+        "strikeouts": strike_events.sum(),
+        "swinging_strike_rate": swinging.mean(),
+        "first_pitch_strike_rate": (
+            first_pitch_strikes.mean() if len(first_pitch) else np.nan
+        ),
+        "csw_pct": ((called | swinging | foul_tip).mean()),
+        "fastball_pct": fastball_mask.mean(),
+        "offspeed_to_fastball_ratio": (
+            offspeed_mask.sum() / fastball_mask.sum() if fastball_mask.sum() else np.nan
+        ),
+        "fastball_then_breaking_rate": (
+            fastball_then_break[:-1].mean() if len(df) > 1 else np.nan
+        ),
+        "avg_release_speed": df["release_speed"].mean(),
+        "max_release_speed": df["release_speed"].max(),
+        "avg_spin_rate": df["release_spin_rate"].mean(),
+        "unique_pitch_types": df["pitch_type"].nunique(),
     }
     return features
+
 
 def aggregate_to_game_level(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
     with DBConnection(db_path) as conn:
         starters = filter_starting_pitchers(conn)
+        total_games = len(starters)
         result_rows = []
-        for game_pk, pitcher in starters.itertuples(index=False):
+        for i, (game_pk, pitcher) in enumerate(
+            starters.itertuples(index=False), start=1
+        ):
             df = load_pitcher_game(conn, game_pk, pitcher)
             if df.empty:
                 continue
             feats = compute_features(df)
             result_rows.append(feats)
+            if i % LOG_EVERY_N == 0:
+                logger.info("Processed %d/%d games", i, total_games)
         game_df = pd.DataFrame(result_rows)
-        game_df.to_sql('game_level_starting_pitchers', conn, index=False, if_exists='replace')
+        game_df.to_sql(
+            "game_level_starting_pitchers", conn, index=False, if_exists="replace"
+        )
     return game_df
+
 
 def main() -> None:
     try:
@@ -112,5 +132,6 @@ def main() -> None:
     except Exception as exc:
         logger.exception("Failed to create starting pitcher table: %s", exc)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- log count of potential starting pitchers
- add periodic progress logs when aggregating
- send logs from `create_starting_pitcher_table.py` to a file
- document logging in README

## Testing
- `pytest -q`