### PR TITLE
Add multiprocessing helper for game-level aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ found and prints progress every 100 games to `logs/create_starting_pitcher_table
 The script also leverages all available CPU cores to process games in parallel,
 dramatically reducing runtime on multi-core machines.
 
+### Multi-core Usage
+
+`create_starting_pitcher_table.py` launches one process per CPU by default. If
+you want to limit the number of workers, set the `MAX_WORKERS` environment
+variable before running the script:
+
+```bash
+MAX_WORKERS=4 python -m src.create_starting_pitcher_table
+```
+
 ## Next Steps
 
 * Finalize feature aggregation logic


### PR DESCRIPTION
## Summary
- use `ProcessPoolExecutor` in `aggregate_to_game_level`
- compute features for one game/pitcher in its own process with a fresh DB connection
- submit tasks in batches and allow worker count override via `MAX_WORKERS`
- document how to limit concurrency in the README

## Testing
- `python -m py_compile src/create_starting_pitcher_table.py`
- `pytest -q`