### PR TITLE
Add batter vs starter and team batting aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ found and prints progress every 100 games to `logs/create_starting_pitcher_table
 The script also leverages all available CPU cores to process games in parallel,
 dramatically reducing runtime on multi-core machines.
 
+### Multi-core Usage
+
+`create_starting_pitcher_table.py` launches one process per CPU by default. If
+you want to limit the number of workers, set the `MAX_WORKERS` environment
+variable before running the script:
+
+```bash
+MAX_WORKERS=4 python -m src.create_starting_pitcher_table
+```
+
 ## Next Steps
 
 * Finalize feature aggregation logic

--- a/src/create_batter_vs_starter_table.py
+++ b/src/create_batter_vs_starter_table.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from typing import Dict, List
+from concurrent.futures import ProcessPoolExecutor, as_completed
+import os
+
+from src.utils import DBConnection, setup_logger
+from src.config import DBConfig, LogConfig
+
+BATTERS_VS_STARTERS_TABLE = "game_level_batters_vs_starters"
+
+logger = setup_logger(
+    "create_batter_vs_starter_table",
+    LogConfig.LOG_DIR / "create_batter_vs_starter_table.log",
+)
+
+LOG_EVERY_N = 100
+MAX_WORKERS = int(os.environ.get("MAX_WORKERS", 9))
+BATCH_SIZE = 500
+
+HIT_EVENTS = {"single", "double", "triple", "home_run"}
+NON_AB_EVENTS = {"walk", "hit_by_pitch", "sac_fly", "sac_bunt", "catcher_interference", "intent_walk"}
+
+
+def get_starting_pitchers(conn) -> pd.DataFrame:
+    """Return starting pitcher IDs per game and team."""
+    query = """
+    WITH pitch_team AS (
+        SELECT
+            game_pk,
+            CASE WHEN inning_topbot = 'Top' THEN home_team ELSE away_team END AS pitching_team,
+            CASE WHEN inning_topbot = 'Top' THEN away_team ELSE home_team END AS opponent_team,
+            pitcher,
+            inning,
+            at_bat_number,
+            pitch_number
+        FROM statcast_pitchers
+    ), ranked AS (
+        SELECT
+            game_pk,
+            pitching_team,
+            opponent_team,
+            pitcher,
+            ROW_NUMBER() OVER (
+                PARTITION BY game_pk, pitching_team, opponent_team
+                ORDER BY inning, at_bat_number, pitch_number
+            ) AS rn
+        FROM pitch_team
+    )
+    SELECT game_pk, pitching_team, opponent_team, pitcher
+    FROM ranked
+    WHERE rn = 1
+    """
+    return pd.read_sql_query(query, conn)
+
+
+def load_batter_game(conn, game_pk: int, pitcher: int) -> pd.DataFrame:
+    q = (
+        "SELECT batter, at_bat_number, pitch_number, events, description, "
+        "balls, strikes, woba_value, woba_denom FROM statcast_batters "
+        "WHERE game_pk = ? AND pitcher = ?"
+    )
+    return pd.read_sql_query(q, conn, params=(game_pk, pitcher))
+
+
+def compute_batter_features(df: pd.DataFrame) -> Dict:
+    df = df.drop_duplicates()
+    df = df.sort_values(["at_bat_number", "pitch_number"]).reset_index(drop=True)
+    num_pitches = len(df)
+    pa_df = df.groupby("at_bat_number").tail(1)
+    plate_appearances = len(pa_df)
+    at_bats_mask = ~pa_df["events"].isin(NON_AB_EVENTS)
+    at_bats = pa_df[at_bats_mask].shape[0]
+
+    hits = pa_df["events"].isin(HIT_EVENTS).sum()
+    singles = pa_df["events"].eq("single").sum()
+    doubles = pa_df["events"].eq("double").sum()
+    triples = pa_df["events"].eq("triple").sum()
+    homers = pa_df["events"].eq("home_run").sum()
+    walks = pa_df["events"].eq("walk").sum()
+    hbp = pa_df["events"].eq("hit_by_pitch").sum()
+    strikeouts = pa_df["events"].str.contains("strikeout", case=False, na=False).sum()
+
+    swings = df["description"].str.contains("swing", case=False, na=False).sum()
+    swings += df["description"].str.contains("foul", case=False, na=False).sum()
+    swings += df["description"].str.contains("hit_into_play", case=False, na=False).sum()
+    whiffs = df["description"].str.contains("swinging_strike", case=False, na=False).sum()
+    called_strikes = df["description"].str.contains("called_strike", case=False, na=False).sum()
+
+    behind_pa = 0
+    behind_k = 0
+    ahead_pa = 0
+    ahead_k = 0
+    for _, grp in df.groupby("at_bat_number"):
+        behind = (grp["strikes"] > grp["balls"]).any()
+        ahead = (grp["balls"] > grp["strikes"]).any()
+        final_event = grp.iloc[-1]["events"]
+        if behind:
+            behind_pa += 1
+            if isinstance(final_event, str) and "strikeout" in final_event.lower():
+                behind_k += 1
+        if ahead:
+            ahead_pa += 1
+            if isinstance(final_event, str) and "strikeout" in final_event.lower():
+                ahead_k += 1
+
+    woba_denom_sum = df["woba_denom"].sum()
+    woba = df["woba_value"].sum() / woba_denom_sum if woba_denom_sum else np.nan
+
+    total_bases = singles + 2 * doubles + 3 * triples + 4 * homers
+    avg = hits / at_bats if at_bats else np.nan
+    obp = (hits + walks + hbp) / plate_appearances if plate_appearances else np.nan
+    slg = total_bases / at_bats if at_bats else np.nan
+    ops = obp + slg if not np.isnan(obp) and not np.isnan(slg) else np.nan
+
+    return {
+        "plate_appearances": plate_appearances,
+        "at_bats": at_bats,
+        "pitches": num_pitches,
+        "swings": swings,
+        "whiffs": whiffs,
+        "whiff_rate": whiffs / swings if swings else np.nan,
+        "called_strike_rate": called_strikes / num_pitches if num_pitches else np.nan,
+        "strikeouts": strikeouts,
+        "strikeout_rate": strikeouts / plate_appearances if plate_appearances else np.nan,
+        "strikeout_rate_behind": behind_k / behind_pa if behind_pa else np.nan,
+        "strikeout_rate_ahead": ahead_k / ahead_pa if ahead_pa else np.nan,
+        "hits": hits,
+        "singles": singles,
+        "doubles": doubles,
+        "triples": triples,
+        "home_runs": homers,
+        "walks": walks,
+        "hbp": hbp,
+        "avg": avg,
+        "obp": obp,
+        "slugging": slg,
+        "ops": ops,
+        "woba": woba,
+    }
+
+
+def compute_game_features(game_pk: int, pitcher: int, pitching_team: str, opponent_team: str, db_path: Path) -> List[Dict]:
+    with DBConnection(db_path) as conn:
+        df = load_batter_game(conn, game_pk, pitcher)
+    if df.empty:
+        return []
+
+    rows: List[Dict] = []
+    for batter_id, bdf in df.groupby("batter"):
+        feats = compute_batter_features(bdf)
+        feats.update(
+            {
+                "game_pk": game_pk,
+                "batter_id": batter_id,
+                "pitcher_id": pitcher,
+                "pitching_team": pitching_team,
+                "opponent_team": opponent_team,
+            }
+        )
+        rows.append(feats)
+    return rows
+
+
+def aggregate_to_game_level(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
+    with DBConnection(db_path) as conn:
+        starters = get_starting_pitchers(conn)
+        total_games = len(starters)
+
+    result_rows: List[Dict] = []
+    processed = 0
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as exc:
+        pending = []
+        for row in starters.itertuples(index=False):
+            pending.append(
+                exc.submit(
+                    compute_game_features,
+                    row.game_pk,
+                    row.pitcher,
+                    row.pitching_team,
+                    row.opponent_team,
+                    db_path,
+                )
+            )
+            if len(pending) >= BATCH_SIZE:
+                for fut in as_completed(pending):
+                    rows = fut.result()
+                    processed += 1
+                    result_rows.extend(rows)
+                    if processed % LOG_EVERY_N == 0:
+                        logger.info("Processed %d/%d games", processed, total_games)
+                pending.clear()
+
+        for fut in as_completed(pending):
+            rows = fut.result()
+            processed += 1
+            result_rows.extend(rows)
+            if processed % LOG_EVERY_N == 0:
+                logger.info("Processed %d/%d games", processed, total_games)
+
+    game_df = pd.DataFrame(result_rows)
+    with DBConnection(db_path) as conn:
+        game_df.to_sql(BATTERS_VS_STARTERS_TABLE, conn, if_exists="replace", index=False)
+    return game_df
+
+
+def main() -> None:
+    try:
+        df = aggregate_to_game_level()
+        logger.info("Aggregated %d batter vs starter rows", len(df))
+    except Exception as exc:
+        logger.exception("Failed to create batter vs starter table: %s", exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/create_team_batting_table.py
+++ b/src/create_team_batting_table.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+from pathlib import Path
+from typing import Dict
+import os
+
+from src.utils import DBConnection, setup_logger
+from src.config import DBConfig, LogConfig
+
+BATTERS_VS_STARTERS_TABLE = "game_level_batters_vs_starters"
+TEAM_BATTING_TABLE = "game_level_team_batting"
+
+logger = setup_logger(
+    "create_team_batting_table",
+    LogConfig.LOG_DIR / "create_team_batting_table.log",
+)
+
+LOG_EVERY_N = 100
+MAX_WORKERS = int(os.environ.get("MAX_WORKERS", 9))
+
+
+def _weighted_average(values: pd.Series, weights: pd.Series) -> float:
+    weights = weights.fillna(0)
+    if weights.sum() == 0:
+        return float('nan')
+    return float(np.average(values.fillna(0), weights=weights))
+
+
+def compute_team_batting_features(df: pd.DataFrame) -> Dict:
+    pa = df["plate_appearances"].sum()
+    ab = df["at_bats"].sum()
+    pitches = df["pitches"].sum()
+    swings = df["swings"].sum()
+    whiffs = df["whiffs"].sum()
+    strikeouts = df["strikeouts"].sum()
+    hits = df["hits"].sum()
+    singles = df["singles"].sum()
+    doubles = df["doubles"].sum()
+    triples = df["triples"].sum()
+    homers = df["home_runs"].sum()
+    walks = df["walks"].sum()
+    hbp = df["hbp"].sum()
+
+    called_strikes = (df["called_strike_rate"] * df["pitches"]).fillna(0).sum()
+    total_bases = singles + 2 * doubles + 3 * triples + 4 * homers
+
+    whiff_rate = whiffs / swings if swings else np.nan
+    called_strike_rate = called_strikes / pitches if pitches else np.nan
+    strikeout_rate = strikeouts / pa if pa else np.nan
+    k_rate_behind = _weighted_average(df["strikeout_rate_behind"], df["plate_appearances"])
+    k_rate_ahead = _weighted_average(df["strikeout_rate_ahead"], df["plate_appearances"])
+    avg = hits / ab if ab else np.nan
+    obp = (hits + walks + hbp) / pa if pa else np.nan
+    slugging = total_bases / ab if ab else np.nan
+    ops = obp + slugging if not np.isnan(obp) and not np.isnan(slugging) else np.nan
+    woba = _weighted_average(df["woba"], df["plate_appearances"])
+
+    return {
+        "bat_plate_appearances": pa,
+        "bat_at_bats": ab,
+        "bat_pitches": pitches,
+        "bat_swings": swings,
+        "bat_whiffs": whiffs,
+        "bat_whiff_rate": whiff_rate,
+        "bat_called_strike_rate": called_strike_rate,
+        "bat_strikeouts": strikeouts,
+        "bat_strikeout_rate": strikeout_rate,
+        "bat_strikeout_rate_behind": k_rate_behind,
+        "bat_strikeout_rate_ahead": k_rate_ahead,
+        "bat_hits": hits,
+        "bat_singles": singles,
+        "bat_doubles": doubles,
+        "bat_triples": triples,
+        "bat_home_runs": homers,
+        "bat_walks": walks,
+        "bat_hbp": hbp,
+        "bat_avg": avg,
+        "bat_obp": obp,
+        "bat_slugging": slugging,
+        "bat_ops": ops,
+        "bat_woba": woba,
+    }
+
+
+def aggregate_to_team_level(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
+    with DBConnection(db_path) as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {BATTERS_VS_STARTERS_TABLE}", conn)
+        if df.empty:
+            return pd.DataFrame()
+
+    rows = []
+    group_cols = ["game_pk", "pitching_team", "opponent_team"]
+    for keys, grp in df.groupby(group_cols):
+        feats = compute_team_batting_features(grp)
+        feats.update({
+            "game_pk": keys[0],
+            "pitching_team": keys[1],
+            "opponent_team": keys[2],
+        })
+        rows.append(feats)
+
+    team_df = pd.DataFrame(rows)
+    with DBConnection(db_path) as conn:
+        team_df.to_sql(TEAM_BATTING_TABLE, conn, if_exists="replace", index=False)
+    return team_df
+
+
+def main() -> None:
+    try:
+        df = aggregate_to_team_level()
+        logger.info("Aggregated %d team batting rows", len(df))
+    except Exception as exc:
+        logger.exception("Failed to create team batting table: %s", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `create_batter_vs_starter_table.py` using multiprocessing and default 9 workers
- add `create_team_batting_table.py` for team level batting features

## Testing
- `python -m py_compile src/create_batter_vs_starter_table.py src/create_team_batting_table.py src/create_starting_pitcher_table.py`
- `pytest -q`