### PR TITLE
Add opponent and contextual feature engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ the difference between the current game value and the previous rolling mean.
 All calculations use a one-game shift to avoid any data that occurs after the
 game begins.
 
+### `rolling_pitcher_vs_team`
+
+Rolling-window statistics for each pitcher against a specific opponent. These
+features are computed from `game_level_matchup_details` and capture how a
+pitcher has performed historically versus that team.
+
+### `contextual_features`
+
+Adds rolling averages for game context variables. Umpire- and weather-specific
+trends are aggregated alongside stadium information based on the home team. Raw
+weather values such as temperature, wind speed and park elevation are also
+included for each game.
+
 
 ## Pipeline Structure
 

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -1,0 +1,10 @@
+"""Feature engineering entry points."""
+
+from .engineer_features import engineer_pitcher_features
+from .contextual import engineer_opponent_features, engineer_contextual_features
+
+__all__ = [
+    "engineer_pitcher_features",
+    "engineer_opponent_features",
+    "engineer_contextual_features",
+]

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import re
+from typing import List, Sequence
+
+import numpy as np
+import pandas as pd
+
+from src.utils import DBConnection, setup_logger
+from src.config import DBConfig, StrikeoutModelConfig, LogConfig
+from .engineer_features import _trend
+
+logger = setup_logger(
+    "contextual_features",
+    LogConfig.LOG_DIR / "contextual_features.log",
+)
+
+
+TEAM_TO_BALLPARK = {
+    "ARI": "Chase Field",
+    "ATL": "Truist Park",
+    "BAL": "Oriole Park at Camden Yards",
+    "BOS": "Fenway Park",
+    "CHC": "Wrigley Field",
+    "CWS": "Guaranteed Rate Field",
+    "CIN": "Great American Ball Park",
+    "CLE": "Progressive Field",
+    "COL": "Coors Field",
+    "DET": "Comerica Park",
+    "HOU": "Minute Maid Park",
+    "KC": "Kauffman Stadium",
+    "LAA": "Angel Stadium",
+    "LAD": "Dodger Stadium",
+    "MIA": "loanDepot Park",
+    "MIL": "American Family Field",
+    "MIN": "Target Field",
+    "NYM": "Citi Field",
+    "NYY": "Yankee Stadium",
+    "OAK": "Oakland Coliseum",
+    "PHI": "Citizens Bank Park",
+    "PIT": "PNC Park",
+    "SD": "Petco Park",
+    "SF": "Oracle Park",
+    "SEA": "T-Mobile Park",
+    "STL": "Busch Stadium",
+    "TB": "Tropicana Field",
+    "TEX": "Globe Life Field",
+    "TOR": "Rogers Centre",
+    "WSH": "Nationals Park",
+}
+
+
+def _parse_wind_speed(value: str | None) -> float:
+    if not value or not isinstance(value, str):
+        return np.nan
+    m = re.search(r"(\d+)", value)
+    return float(m.group(1)) if m else np.nan
+
+
+def _add_group_rolling(
+    df: pd.DataFrame,
+    group_cols: Sequence[str],
+    date_col: str,
+    prefix: str,
+    windows: List[int] | None = None,
+) -> pd.DataFrame:
+    if windows is None:
+        windows = StrikeoutModelConfig.WINDOW_SIZES
+
+    df = df.sort_values(list(group_cols) + [date_col])
+    numeric_cols = [
+        c
+        for c in df.select_dtypes(include=np.number).columns
+        if c not in {"game_pk"}
+    ]
+
+    grouped = df.groupby(list(group_cols))
+    for col in numeric_cols:
+        shifted = grouped[col].shift(1)
+        for window in windows:
+            roll = shifted.rolling(window, min_periods=1)
+            df[f"{prefix}{col}_mean_{window}"] = roll.mean()
+            df[f"{prefix}{col}_std_{window}"] = roll.std()
+            df[f"{prefix}{col}_min_{window}"] = roll.min()
+            df[f"{prefix}{col}_max_{window}"] = roll.max()
+            df[f"{prefix}{col}_trend_{window}"] = roll.apply(_trend, raw=True)
+            df[f"{prefix}{col}_momentum_{window}"] = df[col] - df[f"{prefix}{col}_mean_{window}"]
+    return df
+
+
+def engineer_opponent_features(
+    db_path: str | None = None,
+    source_table: str = "game_level_matchup_details",
+    target_table: str = "rolling_pitcher_vs_team",
+) -> pd.DataFrame:
+    db_path = db_path or DBConfig.PATH
+    logger.info("Loading matchup data from %s", source_table)
+    with DBConnection(db_path) as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {source_table}", conn)
+
+    if df.empty:
+        logger.warning("No data found in %s", source_table)
+        return df
+
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    df = _add_group_rolling(df, ["pitcher_id", "opponent_team"], "game_date", prefix="opp_")
+
+    with DBConnection(db_path) as conn:
+        df.to_sql(target_table, conn, if_exists="replace", index=False)
+    logger.info("Saved opponent features to %s", target_table)
+    return df
+
+
+def engineer_contextual_features(
+    db_path: str | None = None,
+    source_table: str = "game_level_matchup_details",
+    target_table: str = "contextual_features",
+) -> pd.DataFrame:
+    db_path = db_path or DBConfig.PATH
+    logger.info("Loading matchup data from %s", source_table)
+    with DBConnection(db_path) as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {source_table}", conn)
+
+    if df.empty:
+        logger.warning("No data found in %s", source_table)
+        return df
+
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    if "temp" in df.columns:
+        df["temp"] = pd.to_numeric(df["temp"], errors="coerce")
+    if "wind" in df.columns:
+        df["wind_speed"] = df["wind"].apply(_parse_wind_speed)
+    if "elevation" in df.columns:
+        df["elevation"] = pd.to_numeric(df["elevation"], errors="coerce")
+
+    df = _add_group_rolling(df, ["hp_umpire"], "game_date", prefix="ump_")
+    if "weather" in df.columns:
+        df = _add_group_rolling(df, ["weather"], "game_date", prefix="wx_")
+    df = _add_group_rolling(df, ["home_team"], "game_date", prefix="venue_")
+
+    df["stadium"] = df["home_team"].map(TEAM_TO_BALLPARK)
+
+    with DBConnection(db_path) as conn:
+        df.to_sql(target_table, conn, if_exists="replace", index=False)
+    logger.info("Saved contextual features to %s", target_table)
+    return df


### PR DESCRIPTION
## Summary
- implement new `contextual` feature module
- expose new feature builders in `src/features/__init__.py`
- document new SQLite tables in README

## Testing
- `python -m py_compile src/features/contextual.py`
- `python -m py_compile src/features/engineer_features.py`