### PR TITLE
Add feature engineering pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ the difference between the current game value and the previous rolling mean.
 All calculations use a one-game shift to avoid any data that occurs after the
 game begins.
 
+### `rolling_pitcher_vs_team`
+
+Rolling-window statistics for each pitcher against a specific opponent. These
+features are computed from `game_level_matchup_details` and capture how a
+pitcher has performed historically versus that team.
+
+### `contextual_features`
+
+Adds rolling averages for game context variables. Umpire- and weather-specific
+trends are aggregated alongside stadium information based on the home team. Raw
+weather values such as temperature, wind speed and park elevation are also
+included for each game.
+
+### `model_features`
+
+Joined dataset containing all engineered features ready for model training.
+
 
 ## Pipeline Structure
 
@@ -83,7 +100,7 @@ game begins.
    * Pulls recent data from both Statcast and the MLB API
    * Stores raw data in SQLite tables
 
-2. **Aggregation & Feature Engineering** (WIP)
+2. **Aggregation & Feature Engineering**
 
    * Aggregate pitch-level data to game-level stats per pitcher
    * Feature examples: rolling averages, pitch mix %, rest days, weather, batter quality, etc.
@@ -121,10 +138,18 @@ variable before running the script:
 MAX_WORKERS=4 python -m src.create_starting_pitcher_table
 ```
 
+### Running Feature Engineering
+
+Execute all feature builders and produce the `model_features` table:
+
+```bash
+python -m src.scripts.run_feature_engineering --db-path path/to/pitcher_stats.db
+```
+
 ## Next Steps
 
-* Finalize feature aggregation logic
 * Train baseline model and evaluate performance
+* Explore feature importance using SHAP values
 * Add model monitoring & alerting for production use
 
 ## How to Contribute

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -1,0 +1,12 @@
+"""Feature engineering entry points."""
+
+from .engineer_features import engineer_pitcher_features
+from .contextual import engineer_opponent_features, engineer_contextual_features
+from .join import build_model_features
+
+__all__ = [
+    "engineer_pitcher_features",
+    "engineer_opponent_features",
+    "engineer_contextual_features",
+    "build_model_features",
+]

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import re
+from typing import List, Sequence
+
+import numpy as np
+import pandas as pd
+
+from src.utils import DBConnection, setup_logger
+from src.config import DBConfig, StrikeoutModelConfig, LogConfig
+from .engineer_features import _trend
+
+logger = setup_logger(
+    "contextual_features",
+    LogConfig.LOG_DIR / "contextual_features.log",
+)
+
+
+TEAM_TO_BALLPARK = {
+    "ARI": "Chase Field",
+    "ATL": "Truist Park",
+    "BAL": "Oriole Park at Camden Yards",
+    "BOS": "Fenway Park",
+    "CHC": "Wrigley Field",
+    "CWS": "Guaranteed Rate Field",
+    "CIN": "Great American Ball Park",
+    "CLE": "Progressive Field",
+    "COL": "Coors Field",
+    "DET": "Comerica Park",
+    "HOU": "Minute Maid Park",
+    "KC": "Kauffman Stadium",
+    "LAA": "Angel Stadium",
+    "LAD": "Dodger Stadium",
+    "MIA": "loanDepot Park",
+    "MIL": "American Family Field",
+    "MIN": "Target Field",
+    "NYM": "Citi Field",
+    "NYY": "Yankee Stadium",
+    "OAK": "Oakland Coliseum",
+    "PHI": "Citizens Bank Park",
+    "PIT": "PNC Park",
+    "SD": "Petco Park",
+    "SF": "Oracle Park",
+    "SEA": "T-Mobile Park",
+    "STL": "Busch Stadium",
+    "TB": "Tropicana Field",
+    "TEX": "Globe Life Field",
+    "TOR": "Rogers Centre",
+    "WSH": "Nationals Park",
+}
+
+
+def _parse_wind_speed(value: str | None) -> float:
+    if not value or not isinstance(value, str):
+        return np.nan
+    m = re.search(r"(\d+)", value)
+    return float(m.group(1)) if m else np.nan
+
+
+def _add_group_rolling(
+    df: pd.DataFrame,
+    group_cols: Sequence[str],
+    date_col: str,
+    prefix: str,
+    windows: List[int] | None = None,
+) -> pd.DataFrame:
+    if windows is None:
+        windows = StrikeoutModelConfig.WINDOW_SIZES
+
+    df = df.sort_values(list(group_cols) + [date_col])
+    numeric_cols = [
+        c
+        for c in df.select_dtypes(include=np.number).columns
+        if c not in {"game_pk"}
+    ]
+
+    grouped = df.groupby(list(group_cols))
+    frames = [df]
+    for col in numeric_cols:
+        shifted = grouped[col].shift(1)
+        for window in windows:
+            roll = shifted.rolling(window, min_periods=1)
+            mean = roll.mean()
+            stats = pd.DataFrame({
+                f"{prefix}{col}_mean_{window}": mean,
+                f"{prefix}{col}_std_{window}": roll.std(),
+                f"{prefix}{col}_min_{window}": roll.min(),
+                f"{prefix}{col}_max_{window}": roll.max(),
+                f"{prefix}{col}_trend_{window}": roll.apply(_trend, raw=True),
+            })
+            stats[f"{prefix}{col}_momentum_{window}"] = df[col] - mean
+            frames.append(stats)
+
+    df = pd.concat(frames, axis=1)
+    return df
+
+
+def engineer_opponent_features(
+    db_path: str | None = None,
+    source_table: str = "game_level_matchup_details",
+    target_table: str = "rolling_pitcher_vs_team",
+) -> pd.DataFrame:
+    db_path = db_path or DBConfig.PATH
+    logger.info("Loading matchup data from %s", source_table)
+    with DBConnection(db_path) as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {source_table}", conn)
+
+    if df.empty:
+        logger.warning("No data found in %s", source_table)
+        return df
+
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    df = _add_group_rolling(df, ["pitcher_id", "opponent_team"], "game_date", prefix="opp_")
+
+    with DBConnection(db_path) as conn:
+        df.to_sql(target_table, conn, if_exists="replace", index=False)
+    logger.info("Saved opponent features to %s", target_table)
+    return df
+
+
+def engineer_contextual_features(
+    db_path: str | None = None,
+    source_table: str = "game_level_matchup_details",
+    target_table: str = "contextual_features",
+) -> pd.DataFrame:
+    db_path = db_path or DBConfig.PATH
+    logger.info("Loading matchup data from %s", source_table)
+    with DBConnection(db_path) as conn:
+        df = pd.read_sql_query(f"SELECT * FROM {source_table}", conn)
+
+    if df.empty:
+        logger.warning("No data found in %s", source_table)
+        return df
+
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    if "temp" in df.columns:
+        df["temp"] = pd.to_numeric(df["temp"], errors="coerce")
+    if "wind" in df.columns:
+        df["wind_speed"] = df["wind"].apply(_parse_wind_speed)
+    if "elevation" in df.columns:
+        df["elevation"] = pd.to_numeric(df["elevation"], errors="coerce")
+
+    df = _add_group_rolling(df, ["hp_umpire"], "game_date", prefix="ump_")
+    if "weather" in df.columns:
+        df = _add_group_rolling(df, ["weather"], "game_date", prefix="wx_")
+    df = _add_group_rolling(df, ["home_team"], "game_date", prefix="venue_")
+
+    df["stadium"] = df["home_team"].map(TEAM_TO_BALLPARK)
+
+    with DBConnection(db_path) as conn:
+        df.to_sql(target_table, conn, if_exists="replace", index=False)
+    logger.info("Saved contextual features to %s", target_table)
+    return df

--- a/src/features/join.py
+++ b/src/features/join.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+
+from src.utils import DBConnection, setup_logger
+from src.config import DBConfig, LogConfig
+
+logger = setup_logger("join_features", LogConfig.LOG_DIR / "join_features.log")
+
+
+def build_model_features(
+    db_path: Path | None = None,
+    pitcher_table: str = "rolling_pitcher_features",
+    opp_table: str = "rolling_pitcher_vs_team",
+    context_table: str = "contextual_features",
+    target_table: str = "model_features",
+) -> pd.DataFrame:
+    """Join engineered feature tables into one dataset."""
+    db_path = db_path or DBConfig.PATH
+
+    with DBConnection(db_path) as conn:
+        pitcher_df = pd.read_sql_query(f"SELECT * FROM {pitcher_table}", conn)
+        opp_df = pd.read_sql_query(f"SELECT * FROM {opp_table}", conn)
+        ctx_df = pd.read_sql_query(f"SELECT * FROM {context_table}", conn)
+
+    if pitcher_df.empty:
+        logger.warning("No data found in %s", pitcher_table)
+        return pitcher_df
+
+    df = pitcher_df.merge(opp_df, on=["game_pk", "pitcher_id"], how="left")
+    df = df.merge(ctx_df, on=["game_pk", "pitcher_id"], how="left")
+
+    with DBConnection(db_path) as conn:
+        df.to_sql(target_table, conn, if_exists="replace", index=False)
+    logger.info("Saved joined features to %s", target_table)
+    return df

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from src.features import (
+    engineer_pitcher_features,
+    engineer_opponent_features,
+    engineer_contextual_features,
+    build_model_features,
+)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run feature engineering pipeline")
+    parser.add_argument("--db-path", type=Path, default=None, help="Path to SQLite DB")
+    args = parser.parse_args(argv)
+
+    engineer_pitcher_features(db_path=args.db_path)
+    engineer_opponent_features(db_path=args.db_path)
+    engineer_contextual_features(db_path=args.db_path)
+    build_model_features(db_path=args.db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -1,0 +1,51 @@
+import sqlite3
+from pathlib import Path
+import pandas as pd
+
+from src.features import (
+    engineer_pitcher_features,
+    engineer_opponent_features,
+    engineer_contextual_features,
+    build_model_features,
+)
+
+
+def setup_test_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "test.db"
+    with sqlite3.connect(db_path) as conn:
+        pitcher_df = pd.DataFrame({
+            "game_pk": [1, 2, 3],
+            "game_date": pd.to_datetime(["2024-04-01", "2024-04-08", "2024-04-15"]),
+            "pitcher_id": [10, 10, 10],
+            "opponent_team": ["A", "B", "C"],
+            "home_team": ["H1", "H1", "H2"],
+            "hp_umpire": ["U1", "U1", "U2"],
+            "weather": ["Sunny", "Cloudy", "Sunny"],
+            "temp": [70, 65, 60],
+            "wind": ["5 mph", "10 mph", "5 mph"],
+            "elevation": [500, 500, 600],
+            "strikeouts": [5, 6, 7],
+            "pitches": [80, 85, 90],
+        })
+        matchup_df = pitcher_df.copy()
+        pitcher_df.to_sql("game_level_starting_pitchers", conn, index=False)
+        matchup_df.to_sql("game_level_matchup_details", conn, index=False)
+    return db_path
+
+
+def test_feature_pipeline(tmp_path: Path) -> None:
+    db_path = setup_test_db(tmp_path)
+
+    engineer_pitcher_features(db_path=db_path)
+    engineer_opponent_features(db_path=db_path)
+    engineer_contextual_features(db_path=db_path)
+    build_model_features(db_path=db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='model_features'"
+        )
+        assert cur.fetchone() is not None
+        df = pd.read_sql_query("SELECT * FROM model_features", conn)
+        assert len(df) == 3
+        assert any(col.startswith("strikeouts_mean_") for col in df.columns)


### PR DESCRIPTION
## Summary
- implement join step to merge engineered features
- add script `run_feature_engineering` to execute pipeline
- optimize rolling feature builders to avoid fragmented DataFrames
- document how to run feature engineering
- provide tests for the pipeline

## Testing
- `python -m py_compile src/features/engineer_features.py src/features/contextual.py src/features/join.py src/scripts/run_feature_engineering.py tests/test_feature_engineering.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*