### PR TITLE
Fix feature module exports

### DIFF
--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -2,9 +2,11 @@
 
 from .engineer_features import engineer_pitcher_features
 from .contextual import engineer_opponent_features, engineer_contextual_features
+from .join import build_model_features
 
 __all__ = [
     "engineer_pitcher_features",
     "engineer_opponent_features",
     "engineer_contextual_features",
+    "build_model_features",
 ]


### PR DESCRIPTION
## Summary
- expose `build_model_features` from `src.features`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*