### PR TITLE
Add parallel rolling stats option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ Execute all feature builders and produce the `model_features` table:
 python -m src.scripts.run_feature_engineering --db-path path/to/pitcher_stats.db
 ```
 
+Use the `--n-jobs` option to control how many processes are used when computing
+rolling features:
+
+```bash
+python -m src.scripts.run_feature_engineering --db-path path/to/pitcher_stats.db --n-jobs 8
+```
+
 ## Next Steps
 
 * Train baseline model and evaluate performance

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 import re
 from typing import List, Sequence
 
 import numpy as np
 import pandas as pd
+from joblib import Parallel, delayed
 
 from src.utils import DBConnection, setup_logger
 from src.config import DBConfig, StrikeoutModelConfig, LogConfig
@@ -63,34 +65,43 @@ def _add_group_rolling(
     date_col: str,
     prefix: str,
     windows: List[int] | None = None,
+    n_jobs: int | None = None,
 ) -> pd.DataFrame:
     if windows is None:
         windows = StrikeoutModelConfig.WINDOW_SIZES
 
+    if n_jobs is None:
+        n_jobs = os.cpu_count() or 1
+
     df = df.sort_values(list(group_cols) + [date_col])
     exclude_cols = {"game_pk"}.union(set(group_cols))
     numeric_cols = [
-        c
-        for c in df.select_dtypes(include=np.number).columns
-        if c not in exclude_cols
+        c for c in df.select_dtypes(include=np.number).columns if c not in exclude_cols
     ]
 
-    grouped = df.groupby(list(group_cols))
-    frames = [df]
-    for col in numeric_cols:
-        shifted = grouped[col].shift(1)
+    def _calc_for_col(col: str) -> pd.DataFrame:
+        grouped = df.groupby(list(group_cols))[col]
+        shifted = grouped.shift(1)
+        parts = []
         for window in windows:
             roll = shifted.rolling(window, min_periods=1)
             mean = roll.mean()
-            stats = pd.DataFrame({
-                f"{prefix}{col}_mean_{window}": mean,
-                f"{prefix}{col}_std_{window}": roll.std(),
-                f"{prefix}{col}_min_{window}": roll.min(),
-                f"{prefix}{col}_max_{window}": roll.max(),
-                f"{prefix}{col}_trend_{window}": roll.apply(_trend, raw=True),
-            })
+            stats = pd.DataFrame(
+                {
+                    f"{prefix}{col}_mean_{window}": mean,
+                    f"{prefix}{col}_std_{window}": roll.std(),
+                    f"{prefix}{col}_min_{window}": roll.min(),
+                    f"{prefix}{col}_max_{window}": roll.max(),
+                    f"{prefix}{col}_trend_{window}": roll.apply(_trend, raw=True),
+                }
+            )
             stats[f"{prefix}{col}_momentum_{window}"] = df[col] - mean
-            frames.append(stats)
+            parts.append(stats)
+        return pd.concat(parts, axis=1)
+
+    frames = [df]
+    results = Parallel(n_jobs=n_jobs)(delayed(_calc_for_col)(c) for c in numeric_cols)
+    frames.extend(results)
 
     df = pd.concat(frames, axis=1)
     return df
@@ -100,6 +111,7 @@ def engineer_opponent_features(
     db_path: str | None = None,
     source_table: str = "game_level_matchup_details",
     target_table: str = "rolling_pitcher_vs_team",
+    n_jobs: int | None = None,
 ) -> pd.DataFrame:
     db_path = db_path or DBConfig.PATH
     logger.info("Loading matchup data from %s", source_table)
@@ -111,7 +123,13 @@ def engineer_opponent_features(
         return df
 
     df["game_date"] = pd.to_datetime(df["game_date"])
-    df = _add_group_rolling(df, ["pitcher_id", "opponent_team"], "game_date", prefix="opp_")
+    df = _add_group_rolling(
+        df,
+        ["pitcher_id", "opponent_team"],
+        "game_date",
+        prefix="opp_",
+        n_jobs=n_jobs,
+    )
 
     with DBConnection(db_path) as conn:
         df.to_sql(target_table, conn, if_exists="replace", index=False)
@@ -123,6 +141,7 @@ def engineer_contextual_features(
     db_path: str | None = None,
     source_table: str = "game_level_matchup_details",
     target_table: str = "contextual_features",
+    n_jobs: int | None = None,
 ) -> pd.DataFrame:
     db_path = db_path or DBConfig.PATH
     logger.info("Loading matchup data from %s", source_table)
@@ -141,10 +160,16 @@ def engineer_contextual_features(
     if "elevation" in df.columns:
         df["elevation"] = pd.to_numeric(df["elevation"], errors="coerce")
 
-    df = _add_group_rolling(df, ["hp_umpire"], "game_date", prefix="ump_")
+    df = _add_group_rolling(
+        df, ["hp_umpire"], "game_date", prefix="ump_", n_jobs=n_jobs
+    )
     if "weather" in df.columns:
-        df = _add_group_rolling(df, ["weather"], "game_date", prefix="wx_")
-    df = _add_group_rolling(df, ["home_team"], "game_date", prefix="venue_")
+        df = _add_group_rolling(
+            df, ["weather"], "game_date", prefix="wx_", n_jobs=n_jobs
+        )
+    df = _add_group_rolling(
+        df, ["home_team"], "game_date", prefix="venue_", n_jobs=n_jobs
+    )
 
     df["stadium"] = df["home_team"].map(TEAM_TO_BALLPARK)
 

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -14,11 +14,17 @@ from src.features import (
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run feature engineering pipeline")
     parser.add_argument("--db-path", type=Path, default=None, help="Path to SQLite DB")
+    parser.add_argument(
+        "--n-jobs",
+        type=int,
+        default=None,
+        help="Number of parallel workers for rolling features",
+    )
     args = parser.parse_args(argv)
 
     engineer_pitcher_features(db_path=args.db_path)
-    engineer_opponent_features(db_path=args.db_path)
-    engineer_contextual_features(db_path=args.db_path)
+    engineer_opponent_features(db_path=args.db_path, n_jobs=args.n_jobs)
+    engineer_contextual_features(db_path=args.db_path, n_jobs=args.n_jobs)
     build_model_features(db_path=args.db_path)
 
 


### PR DESCRIPTION
## Summary
- add `--n-jobs` CLI option for feature engineering
- compute contextual rolling features in parallel using joblib
- expose worker count through feature engineering scripts
- document multi-core option in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*