### PR TITLE
Add MAX_WORKERS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ dramatically reducing runtime on multi-core machines.
 
 ### Multi-core Usage
 
-`create_starting_pitcher_table.py` launches one process per CPU by default. If
-you want to limit the number of workers, set the `MAX_WORKERS` environment
-variable before running the script:
+`create_starting_pitcher_table.py` launches one process per CPU by default.
+The worker count is controlled by `DataConfig.MAX_WORKERS`, which can be
+overridden via the `MAX_WORKERS` environment variable:
 
 ```bash
 MAX_WORKERS=4 python -m src.create_starting_pitcher_table

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 import logging
+import os
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
@@ -60,6 +61,7 @@ class DataConfig:
     SEASONS = [2016, 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025]
     RATE_LIMIT_PAUSE = 5
     CHUNK_SIZE = 1000000
+    MAX_WORKERS = int(os.getenv('MAX_WORKERS', os.cpu_count() or 1))
 
 class StrikeoutModelConfig:
     RANDOM_STATE = 3

--- a/src/scripts/data_fetcher.py
+++ b/src/scripts/data_fetcher.py
@@ -660,7 +660,7 @@ class DataFetcher:
 
         # --- Parallel vs Sequential Execution ---
         if self.args.parallel:
-            workers = min(DataConfig.MAX_WORKERS, os.cpu_count() or 1) if hasattr(DataConfig, 'MAX_WORKERS') else min(12, os.cpu_count() or 1)
+            workers = min(DataConfig.MAX_WORKERS, os.cpu_count() or 1)
             logger.info(f"Using PARALLEL pitcher fetch ({workers} workers).")
             with ThreadPoolExecutor(max_workers=workers) as executor:
                 # Map futures back to pitcher info
@@ -995,7 +995,7 @@ class DataFetcher:
             successful_end_dates = [] # Collect end dates of successfully processed chunks
 
             if self.args.parallel:
-                workers = min(DataConfig.MAX_WORKERS, os.cpu_count() or 1) if hasattr(DataConfig, 'MAX_WORKERS') else min(8, os.cpu_count() or 1) # Slightly fewer for batters maybe?
+                workers = min(DataConfig.MAX_WORKERS, os.cpu_count() or 1)
                 logger.info(f"Using PARALLEL batter fetch for season {season} ({workers} workers).")
                 with ThreadPoolExecutor(max_workers=workers) as executor:
                     future_to_range = {


### PR DESCRIPTION
## Summary
- make worker count configurable via DataConfig.MAX_WORKERS
- use the new config in data_fetcher
- document MAX_WORKERS in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*