### PR TITLE
Simplify rolling feature engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Joins `game_level_starting_pitchers` with `game_level_team_batting` so each row 
 
 Derived from `game_level_starting_pitchers`, this table contains rolling-window
 statistics for each pitcher. For every numeric metric we compute prior-game
-means, extrema, standard deviations and linear trend slopes over the window
-sizes defined in `StrikeoutModelConfig.WINDOW_SIZES`. Momentum features capture
-the difference between the current game value and the previous rolling mean.
+means and standard deviations over the window sizes defined in
+`StrikeoutModelConfig.WINDOW_SIZES`. Momentum features capture the difference
+between the current game value and the previous rolling mean.
 All calculations use a one-game shift to avoid any data that occurs after the
 game begins.
 

--- a/src/config.py
+++ b/src/config.py
@@ -65,7 +65,8 @@ class DataConfig:
 
 class StrikeoutModelConfig:
     RANDOM_STATE = 3
-    WINDOW_SIZES = [3, 5, 10, 25]
+    # Fewer windows to speed up feature engineering
+    WINDOW_SIZES = [5, 10]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)
     TARGET_VARIABLE = "strikeouts"

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -14,7 +14,6 @@ from src.utils import (
     get_latest_date,
 )
 from src.config import DBConfig, StrikeoutModelConfig, LogConfig
-from .engineer_features import _trend
 
 logger = setup_logger(
     "contextual_features",
@@ -95,9 +94,6 @@ def _add_group_rolling(
                 {
                     f"{prefix}{col}_mean_{window}": mean,
                     f"{prefix}{col}_std_{window}": roll.std(),
-                    f"{prefix}{col}_min_{window}": roll.min(),
-                    f"{prefix}{col}_max_{window}": roll.max(),
-                    f"{prefix}{col}_trend_{window}": roll.apply(_trend, raw=True),
                 }
             )
             stats[f"{prefix}{col}_momentum_{window}"] = local_df[col] - mean

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -20,23 +20,13 @@ logger = setup_logger(
     LogConfig.LOG_DIR / "engineer_features.log",
 )
 
-
-def _trend(values: np.ndarray) -> float:
-    """Return the slope of a simple linear regression for the input values."""
-    if len(values) < 2:
-        return np.nan
-    x = np.arange(len(values))
-    slope, _ = np.polyfit(x, values, 1)
-    return float(slope)
-
-
 def add_rolling_features(
     df: pd.DataFrame,
     group_col: str,
     date_col: str,
     windows: List[int] | None = None,
 ) -> pd.DataFrame:
-    """Add rolling stats, momentum, and trend features to ``df``.
+    """Add rolling statistics and momentum features to ``df``.
 
     Parameters
     ----------
@@ -66,13 +56,13 @@ def add_rolling_features(
         for window in windows:
             roll = shifted.rolling(window, min_periods=1)
             mean = roll.mean()
-            stats = pd.DataFrame({
-                f"{col}_mean_{window}": mean,
-                f"{col}_std_{window}": roll.std(),
-                f"{col}_min_{window}": roll.min(),
-                f"{col}_max_{window}": roll.max(),
-                f"{col}_trend_{window}": roll.apply(_trend, raw=True),
-            })
+            stats = pd.DataFrame(
+                {
+                    f"{col}_mean_{window}": mean,
+                    f"{col}_std_{window}": roll.std(),
+                }
+            )
+            # Momentum captures the difference from recent average
             stats[f"{col}_momentum_{window}"] = df[col] - mean
             frames.append(stats)
 


### PR DESCRIPTION
## Summary
- limit rolling window sizes to `[5, 10]`
- drop min/max/trend calculations in feature engineering
- update README description

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*