### PR TITLE
Purge old window features

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -99,10 +99,14 @@ def _add_group_rolling(
     exclude_cols = {"game_pk"}.union(set(group_cols))
     if numeric_cols is None:
         numeric_cols = [
-            c for c in df.select_dtypes(include=np.number).columns if c not in exclude_cols
+            c
+            for c in df.select_dtypes(include=np.number).columns
+            if c not in exclude_cols
         ]
     else:
-        numeric_cols = [c for c in numeric_cols if c in df.columns and c not in exclude_cols]
+        numeric_cols = [
+            c for c in numeric_cols if c in df.columns and c not in exclude_cols
+        ]
 
     def _calc_for_col(col: str, local_df: pd.DataFrame) -> pd.DataFrame:
         """Calculate rolling stats for a single column using a dataframe slice."""
@@ -138,16 +142,31 @@ def engineer_opponent_features(
     target_table: str = "rolling_pitcher_vs_team",
     n_jobs: int | None = None,
     year: int | None = None,
+    rebuild: bool = False,
 ) -> pd.DataFrame:
+    """Compute rolling opponent statistics for each pitcher/team matchup.
+
+    Parameters
+    ----------
+    rebuild : bool, default False
+        When ``True`` the ``target_table`` is dropped before new rows are
+        inserted so only features using the current window sizes remain.
+    """
+
     db_path = db_path or DBConfig.PATH
     logger.info("Loading matchup data from %s", source_table)
     max_window = max(StrikeoutModelConfig.WINDOW_SIZES)
     with DBConnection(db_path) as conn:
+        if rebuild and table_exists(conn, target_table):
+            conn.execute(f"DROP TABLE IF EXISTS {target_table}")
+            latest = None
+        else:
+            latest = get_latest_date(conn, target_table, "game_date")
+
         query = f"SELECT * FROM {source_table}"
         if year:
             query += f" WHERE strftime('%Y', game_date) = '{year}'"
         df = pd.read_sql_query(query, conn)
-        latest = get_latest_date(conn, target_table, "game_date")
 
         if df.empty:
             logger.warning("No data found in %s", source_table)
@@ -167,12 +186,13 @@ def engineer_opponent_features(
             n_jobs=n_jobs,
             numeric_cols=StrikeoutModelConfig.PITCHER_ROLLING_COLS,
         )
-        if table_exists(conn, target_table):
-            df.to_sql(target_table, conn, if_exists="append", index=False)
-        else:
+        if rebuild or not table_exists(conn, target_table):
             df.to_sql(target_table, conn, if_exists="replace", index=False)
+        else:
+            df.to_sql(target_table, conn, if_exists="append", index=False)
         logger.info("Saved opponent features to %s", target_table)
         return df
+
 
 def engineer_contextual_features(
     db_path: str | None = None,
@@ -180,16 +200,30 @@ def engineer_contextual_features(
     target_table: str = "contextual_features",
     n_jobs: int | None = None,
     year: int | None = None,
+    rebuild: bool = False,
 ) -> pd.DataFrame:
+    """Aggregate contextual factors and compute rolling statistics.
+
+    Parameters
+    ----------
+    rebuild : bool, default False
+        Drop and recreate ``target_table`` so outdated window sizes are removed.
+    """
+
     db_path = db_path or DBConfig.PATH
     logger.info("Loading matchup data from %s", source_table)
     max_window = max(StrikeoutModelConfig.WINDOW_SIZES)
     with DBConnection(db_path) as conn:
+        if rebuild and table_exists(conn, target_table):
+            conn.execute(f"DROP TABLE IF EXISTS {target_table}")
+            latest = None
+        else:
+            latest = get_latest_date(conn, target_table, "game_date")
+
         query = f"SELECT * FROM {source_table}"
         if year:
             query += f" WHERE strftime('%Y', game_date) = '{year}'"
         df = pd.read_sql_query(query, conn)
-        latest = get_latest_date(conn, target_table, "game_date")
 
         if df.empty:
             logger.warning("No data found in %s", source_table)
@@ -237,9 +271,9 @@ def engineer_contextual_features(
 
         df["stadium"] = df["home_team"].map(TEAM_TO_BALLPARK)
 
-        if table_exists(conn, target_table):
-            df.to_sql(target_table, conn, if_exists="append", index=False)
-        else:
+        if rebuild or not table_exists(conn, target_table):
             df.to_sql(target_table, conn, if_exists="replace", index=False)
+        else:
+            df.to_sql(target_table, conn, if_exists="append", index=False)
         logger.info("Saved contextual features to %s", target_table)
         return df

--- a/src/features/join.py
+++ b/src/features/join.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 from src.utils import DBConnection, setup_logger
 from src.utils import table_exists, get_latest_date
-from src.config import DBConfig, LogConfig
+from src.config import DBConfig, LogConfig, StrikeoutModelConfig
+import re
 
 logger = setup_logger("join_features", LogConfig.LOG_DIR / "join_features.log")
 
@@ -17,25 +18,37 @@ def build_model_features(
     context_table: str = "contextual_features",
     target_table: str = "model_features",
     year: int | None = None,
+    rebuild: bool = False,
 ) -> pd.DataFrame:
-    """Join engineered feature tables into one dataset."""
+    """Join engineered feature tables into one dataset.
+
+    Parameters
+    ----------
+    rebuild : bool, default False
+        Drop ``target_table`` and recreate it with only the configured window
+        sizes.
+    """
     db_path = db_path or DBConfig.PATH
 
+    valid_windows = {str(w) for w in StrikeoutModelConfig.WINDOW_SIZES}
+    pattern = re.compile(r"_(?:mean|std|momentum)_(\d+)$")
+
     with DBConnection(db_path) as conn:
+        if rebuild and table_exists(conn, target_table):
+            conn.execute(f"DROP TABLE IF EXISTS {target_table}")
+            latest = None
+        else:
+            latest = get_latest_date(conn, target_table, "game_date")
+
         base_query = "SELECT * FROM {}"
-        filter_clause = (
-            f" WHERE strftime('%Y', game_date) = '{year}'" if year else ""
-        )
+        filter_clause = f" WHERE strftime('%Y', game_date) = '{year}'" if year else ""
         pitcher_df = pd.read_sql_query(
             base_query.format(pitcher_table) + filter_clause, conn
         )
-        opp_df = pd.read_sql_query(
-            base_query.format(opp_table) + filter_clause, conn
-        )
+        opp_df = pd.read_sql_query(base_query.format(opp_table) + filter_clause, conn)
         ctx_df = pd.read_sql_query(
             base_query.format(context_table) + filter_clause, conn
         )
-        latest = get_latest_date(conn, target_table, "game_date")
 
         if pitcher_df.empty:
             logger.warning("No data found in %s", pitcher_table)
@@ -45,13 +58,22 @@ def build_model_features(
         df = df.merge(ctx_df, on=["game_pk", "pitcher_id"], how="left")
         if latest is not None:
             df = df[df["game_date"] > latest]
+
+        # Drop columns created with window sizes not in config
+        drop_cols = [
+            c
+            for c in df.columns
+            if (m := pattern.search(c)) and m.group(1) not in valid_windows
+        ]
+        if drop_cols:
+            df = df.drop(columns=drop_cols)
         if df.empty:
             logger.info("No new rows to process for %s", target_table)
             return df
 
-        if table_exists(conn, target_table):
-            df.to_sql(target_table, conn, if_exists="append", index=False)
-        else:
+        if rebuild or not table_exists(conn, target_table):
             df.to_sql(target_table, conn, if_exists="replace", index=False)
+        else:
+            df.to_sql(target_table, conn, if_exists="append", index=False)
         logger.info("Saved joined features to %s", target_table)
         return df

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -26,12 +26,29 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Process only games from the specified year",
     )
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Drop existing feature tables and recreate them",
+    )
     args = parser.parse_args(argv)
 
-    engineer_pitcher_features(db_path=args.db_path, year=args.year)
-    engineer_opponent_features(db_path=args.db_path, n_jobs=args.n_jobs, year=args.year)
-    engineer_contextual_features(db_path=args.db_path, n_jobs=args.n_jobs, year=args.year)
-    build_model_features(db_path=args.db_path, year=args.year)
+    engineer_pitcher_features(
+        db_path=args.db_path, year=args.year, rebuild=args.rebuild
+    )
+    engineer_opponent_features(
+        db_path=args.db_path,
+        n_jobs=args.n_jobs,
+        year=args.year,
+        rebuild=args.rebuild,
+    )
+    engineer_contextual_features(
+        db_path=args.db_path,
+        n_jobs=args.n_jobs,
+        year=args.year,
+        rebuild=args.rebuild,
+    )
+    build_model_features(db_path=args.db_path, year=args.year, rebuild=args.rebuild)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow feature engineering scripts to rebuild tables
- drop stale rolling features in `build_model_features`
- add `--rebuild` CLI option
- test that old window columns are removed

## Testing
- `pytest -q` *(fails: No module named 'pandas')*