### PR TITLE
Fix momentum feature leakage

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -122,7 +122,7 @@ def _add_group_rolling(
                     f"{prefix}{col}_std_{window}": roll.std(),
                 }
             )
-            stats[f"{prefix}{col}_momentum_{window}"] = local_df[col] - mean
+            stats[f"{prefix}{col}_momentum_{window}"] = shifted - mean
             parts.append(stats)
         return pd.concat(parts, axis=1)
 

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -74,8 +74,8 @@ def add_rolling_features(
                     f"{col}_std_{window}": roll.std(),
                 }
             )
-            # Momentum captures the difference from recent average
-            stats[f"{col}_momentum_{window}"] = df[col] - mean
+            # Momentum compares last game's value to the previous average
+            stats[f"{col}_momentum_{window}"] = shifted - mean
             frames.append(stats)
 
     df = pd.concat(frames, axis=1)


### PR DESCRIPTION
## Summary
- prevent data leakage in rolling stats by shifting before momentum calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*