### PR TITLE
Fix rolling stats to respect groups

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -114,12 +114,17 @@ def _add_group_rolling(
         shifted = grouped.shift(1)
         parts = []
         for window in windows:
-            roll = shifted.rolling(window, min_periods=1)
-            mean = roll.mean()
+            roll = (
+                shifted
+                .groupby([local_df[c] for c in group_cols])
+                .rolling(window, min_periods=1)
+            )
+            mean = roll.mean().reset_index(level=list(range(len(group_cols))), drop=True)
+            std = roll.std().reset_index(level=list(range(len(group_cols))), drop=True)
             stats = pd.DataFrame(
                 {
                     f"{prefix}{col}_mean_{window}": mean,
-                    f"{prefix}{col}_std_{window}": roll.std(),
+                    f"{prefix}{col}_std_{window}": std,
                 }
             )
             stats[f"{prefix}{col}_momentum_{window}"] = shifted - mean

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -66,12 +66,17 @@ def add_rolling_features(
         grouped = df.groupby(group_col)[col]
         shifted = grouped.shift(1)
         for window in windows:
-            roll = shifted.rolling(window, min_periods=1)
-            mean = roll.mean()
+            roll = (
+                shifted
+                .groupby(df[group_col])
+                .rolling(window, min_periods=1)
+            )
+            mean = roll.mean().reset_index(level=0, drop=True)
+            std = roll.std().reset_index(level=0, drop=True)
             stats = pd.DataFrame(
                 {
                     f"{col}_mean_{window}": mean,
-                    f"{col}_std_{window}": roll.std(),
+                    f"{col}_std_{window}": std,
                 }
             )
             # Momentum compares last game's value to the previous average

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -8,6 +8,8 @@ from src.features import (
     engineer_contextual_features,
     build_model_features,
 )
+from src.features.engineer_features import add_rolling_features
+from src.features.contextual import _add_group_rolling
 
 
 def setup_test_db(tmp_path: Path) -> Path:
@@ -75,3 +77,60 @@ def test_old_window_columns_removed(tmp_path: Path) -> None:
     with sqlite3.connect(db_path) as conn:
         df = pd.read_sql_query("SELECT * FROM model_features", conn)
         assert all("_mean_5" not in c for c in df.columns)
+
+
+def test_rolling_stats_isolated_by_group() -> None:
+    df = pd.DataFrame(
+        {
+            "game_pk": [1, 2, 3, 4],
+            "game_date": pd.to_datetime([
+                "2024-04-01",
+                "2024-04-02",
+                "2024-04-01",
+                "2024-04-02",
+            ]),
+            "pitcher_id": [1, 1, 2, 2],
+            "strikeouts": [5, 6, 7, 8],
+        }
+    )
+
+    out = add_rolling_features(
+        df,
+        group_col="pitcher_id",
+        date_col="game_date",
+        windows=[2],
+        numeric_cols=["strikeouts"],
+    )
+
+    assert pd.isna(out.loc[2, "strikeouts_mean_2"])
+    assert out.loc[3, "strikeouts_mean_2"] == 7
+
+
+def test_group_rolling_multiple_keys() -> None:
+    df = pd.DataFrame(
+        {
+            "game_pk": [1, 2, 3, 4],
+            "game_date": pd.to_datetime([
+                "2024-04-01",
+                "2024-04-08",
+                "2024-04-01",
+                "2024-04-08",
+            ]),
+            "pitcher_id": [10, 10, 20, 20],
+            "opponent_team": ["A", "A", "B", "B"],
+            "strikeouts": [5, 6, 7, 8],
+        }
+    )
+
+    res = _add_group_rolling(
+        df,
+        ["pitcher_id", "opponent_team"],
+        "game_date",
+        prefix="opp_",
+        windows=[2],
+        n_jobs=1,
+        numeric_cols=["strikeouts"],
+    )
+
+    assert pd.isna(res.loc[2, "opp_strikeouts_mean_2"])
+    assert res.loc[3, "opp_strikeouts_mean_2"] == 7


### PR DESCRIPTION
## Summary
- ensure rolling stats are calculated within each group
- update contextual rolling logic
- expand tests for grouped rolling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*