### PR TITLE
Expand rolling windows

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -66,7 +66,8 @@ class DataConfig:
 class StrikeoutModelConfig:
     RANDOM_STATE = 3
     # Dramatically smaller windows to keep feature counts manageable
-    WINDOW_SIZES = [3]
+    # Expanded windows to provide more temporal context
+    WINDOW_SIZES = [3, 5, 10]
     # Limit which numeric columns get rolling stats to avoid huge tables
     PITCHER_ROLLING_COLS = ["strikeouts", "pitches"]
     CONTEXT_ROLLING_COLS = ["strikeouts", "pitches", "temp", "wind_speed", "elevation"]

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -50,8 +50,9 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert cur.fetchone() is not None
         df = pd.read_sql_query("SELECT * FROM model_features", conn)
         assert len(df) == 3
-        assert any(col == "strikeouts_mean_3" for col in df.columns)
-        assert all("_mean_5" not in c for c in df.columns)
+        assert "strikeouts_mean_3" in df.columns
+        assert "strikeouts_mean_5" in df.columns
+        assert "strikeouts_mean_10" in df.columns
         # ensure raw game stats are dropped
         assert "pitches" not in df.columns
 
@@ -64,17 +65,17 @@ def test_old_window_columns_removed(tmp_path: Path) -> None:
     engineer_opponent_features(db_path=db_path)
     engineer_contextual_features(db_path=db_path)
 
-    # Manually add a column using an old window size
+    # Manually add a column using an unsupported window size
     with sqlite3.connect(db_path) as conn:
         df = pd.read_sql_query("SELECT * FROM rolling_pitcher_features", conn)
-        df["strikeouts_mean_5"] = 1
+        df["strikeouts_mean_99"] = 1
         df.to_sql("rolling_pitcher_features", conn, if_exists="replace", index=False)
 
     build_model_features(db_path=db_path)
 
     with sqlite3.connect(db_path) as conn:
         df = pd.read_sql_query("SELECT * FROM model_features", conn)
-        assert all("_mean_5" not in c for c in df.columns)
+        assert all("_mean_99" not in c for c in df.columns)
 
 def test_group_specific_rolling() -> None:
     df = pd.DataFrame(


### PR DESCRIPTION
## Summary
- support additional rolling windows via StrikeoutModelConfig
- validate new windows in feature engineering tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*