### PR TITLE
Add team strikeout rate vs hand features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -70,6 +70,7 @@ class StrikeoutModelConfig:
     # Limit which numeric columns get rolling stats to avoid huge tables
     PITCHER_ROLLING_COLS = ["strikeouts", "pitches"]
     CONTEXT_ROLLING_COLS = ["strikeouts", "pitches", "temp", "wind_speed", "elevation"]
+    TEAM_HAND_RATE_COLS = ["team_k_rate"]
     # Numeric columns that may be used without rolling (known before the game)
     ALLOWED_BASE_NUMERIC_COLS = ["temp", "wind_speed", "elevation"]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -168,6 +168,23 @@ def engineer_opponent_features(
             query += f" WHERE strftime('%Y', game_date) = '{year}'"
         df = pd.read_sql_query(query, conn)
 
+        hand_query = """
+            SELECT b.game_pk,
+                   b.opponent_team,
+                   s.pitcher_hand,
+                   SUM(b.strikeouts) AS strikeouts,
+                   SUM(b.plate_appearances) AS plate_appearances
+            FROM game_level_batters_vs_starters b
+            JOIN game_level_starting_pitchers s
+              ON b.game_pk = s.game_pk AND b.pitcher_id = s.pitcher_id
+            GROUP BY b.game_pk, b.opponent_team, s.pitcher_hand
+        """
+        hand_df = pd.read_sql_query(hand_query, conn)
+        if not hand_df.empty:
+            hand_df["team_k_rate"] = hand_df["strikeouts"] / hand_df["plate_appearances"]
+            hand_df = hand_df[["game_pk", "opponent_team", "pitcher_hand", "team_k_rate"]]
+            df = df.merge(hand_df, on=["game_pk", "opponent_team", "pitcher_hand"], how="left")
+
         if df.empty:
             logger.warning("No data found in %s", source_table)
             return df
@@ -186,6 +203,16 @@ def engineer_opponent_features(
             n_jobs=n_jobs,
             numeric_cols=StrikeoutModelConfig.PITCHER_ROLLING_COLS,
         )
+        if "team_k_rate" in df.columns:
+            df = _add_group_rolling(
+                df,
+                ["opponent_team", "pitcher_hand"],
+                "game_date",
+                prefix="team_hand_",
+                n_jobs=n_jobs,
+                numeric_cols=["team_k_rate"],
+            )
+            df = df.drop(columns=["team_k_rate"])
         if rebuild or not table_exists(conn, target_table):
             df.to_sql(target_table, conn, if_exists="replace", index=False)
         else:

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -18,6 +18,7 @@ def setup_test_db(tmp_path: Path) -> Path:
                 "game_pk": [1, 2, 3],
                 "game_date": pd.to_datetime(["2024-04-01", "2024-04-08", "2024-04-15"]),
                 "pitcher_id": [10, 10, 10],
+                "pitcher_hand": ["R", "L", "R"],
                 "opponent_team": ["A", "B", "C"],
                 "home_team": ["H1", "H1", "H2"],
                 "hp_umpire": ["U1", "U1", "U2"],
@@ -32,6 +33,17 @@ def setup_test_db(tmp_path: Path) -> Path:
         matchup_df = pitcher_df.copy()
         pitcher_df.to_sql("game_level_starting_pitchers", conn, index=False)
         matchup_df.to_sql("game_level_matchup_details", conn, index=False)
+
+        batter_df = pd.DataFrame(
+            {
+                "game_pk": [1, 2, 3],
+                "pitcher_id": [10, 10, 10],
+                "opponent_team": ["A", "B", "C"],
+                "plate_appearances": [4, 4, 4],
+                "strikeouts": [1, 2, 1],
+            }
+        )
+        batter_df.to_sql("game_level_batters_vs_starters", conn, index=False)
     return db_path
 
 


### PR DESCRIPTION
## Summary
- compute team strikeout rate versus pitcher hand from `statcast_batters`
- roll these metrics per opponent in `engineer_opponent_features`
- expose `TEAM_HAND_RATE_COLS` config entry
- update test fixtures for new table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*