### PR TITLE
Add FIP rolling features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -68,7 +68,7 @@ class StrikeoutModelConfig:
     # Dramatically smaller windows to keep feature counts manageable
     WINDOW_SIZES = [3]
     # Limit which numeric columns get rolling stats to avoid huge tables
-    PITCHER_ROLLING_COLS = ["strikeouts", "pitches"]
+    PITCHER_ROLLING_COLS = ["strikeouts", "pitches", "fip"]
     CONTEXT_ROLLING_COLS = ["strikeouts", "pitches", "temp", "wind_speed", "elevation"]
     # Numeric columns that may be used without rolling (known before the game)
     ALLOWED_BASE_NUMERIC_COLS = ["temp", "wind_speed", "elevation"]

--- a/src/data/create_starting_pitcher_table.py
+++ b/src/data/create_starting_pitcher_table.py
@@ -116,6 +116,21 @@ def compute_features(df: pd.DataFrame) -> Dict:
         "max_release_speed": df["release_speed"].max(),
         "avg_spin_rate": df["release_spin_rate"].mean(),
         "unique_pitch_types": df["pitch_type"].nunique(),
+        # FIP formula without constant: (13*HR + 3*(BB+HBP) - 2*K) / IP
+        "fip": (
+            (
+                13 * df["events"].eq("home_run").sum()
+                + 3
+                * (
+                    df["events"].isin(["walk", "intent_walk"]).sum()
+                    + df["events"].eq("hit_by_pitch").sum()
+                )
+                - 2 * strike_events.sum()
+            )
+            / df["inning"].nunique()
+            if df["inning"].nunique()
+            else np.nan
+        ),
     }
     return features
 

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -27,6 +27,7 @@ def setup_test_db(tmp_path: Path) -> Path:
                 "elevation": [500, 500, 600],
                 "strikeouts": [5, 6, 7],
                 "pitches": [80, 85, 90],
+                "fip": [4.0, 3.5, 3.0],
             }
         )
         matchup_df = pitcher_df.copy()
@@ -51,6 +52,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         df = pd.read_sql_query("SELECT * FROM model_features", conn)
         assert len(df) == 3
         assert any(col == "strikeouts_mean_3" for col in df.columns)
+        assert any(col == "fip_mean_3" for col in df.columns)
         assert all("_mean_5" not in c for c in df.columns)
         # ensure raw game stats are dropped
         assert "pitches" not in df.columns
@@ -68,6 +70,7 @@ def test_old_window_columns_removed(tmp_path: Path) -> None:
     with sqlite3.connect(db_path) as conn:
         df = pd.read_sql_query("SELECT * FROM rolling_pitcher_features", conn)
         df["strikeouts_mean_5"] = 1
+        df["fip_mean_5"] = 1
         df.to_sql("rolling_pitcher_features", conn, if_exists="replace", index=False)
 
     build_model_features(db_path=db_path)


### PR DESCRIPTION
## Summary
- compute per-game FIP when creating the starting pitcher table
- roll FIP stats in `engineer_pitcher_features`
- update tests for the new feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*