### PR TITLE
Fix duplicate pandas import

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -9,7 +9,6 @@ from datetime import datetime
 import pandas as pd
 
 from src.config import DBConfig
-import pandas as pd
 
 class DBConnection:
     """Simple context manager for SQLite connections."""


### PR DESCRIPTION
## Summary
- tidy utils import block by removing duplicate `pandas` import

## Testing
- `python -m py_compile src/utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*