### PR TITLE
Update rolling feature columns

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -206,7 +206,7 @@ def engineer_opponent_features(
             "game_date",
             prefix="opp_",
             n_jobs=n_jobs,
-            numeric_cols=StrikeoutModelConfig.PITCHER_ROLLING_COLS,
+            numeric_cols=StrikeoutModelConfig.CONTEXT_ROLLING_COLS,
         )
         if "team_k_rate" in df.columns:
             df = _add_group_rolling(

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -151,6 +151,7 @@ def engineer_pitcher_features(
         df,
         group_col="pitcher_id",
         date_col="game_date",
+        windows=StrikeoutModelConfig.WINDOW_SIZES,
         numeric_cols=StrikeoutModelConfig.PITCHER_ROLLING_COLS,
     )
 


### PR DESCRIPTION
## Summary
- use window sizes and rolling columns from config when building pitcher features
- compute opponent rolling stats with contextual columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*