### PR TITLE
Retain base contextual stats for model dataset

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -117,7 +117,15 @@ class StrikeoutModelConfig:
         "park_factor",
     ]
     # Numeric columns that may be used without rolling (known before the game)
-    ALLOWED_BASE_NUMERIC_COLS = ["temp", "wind_speed", "elevation", "rest_days"]
+    ALLOWED_BASE_NUMERIC_COLS = [
+        "temp",
+        "wind_speed",
+        "elevation",
+        "rest_days",
+        "humidity",
+        "park_factor",
+        "team_k_rate",
+    ]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)
     TARGET_VARIABLE = "strikeouts"

--- a/src/features/join.py
+++ b/src/features/join.py
@@ -93,11 +93,16 @@ def build_model_features(
             df = df.drop(columns=drop_cols)
 
         # Remove numeric columns that are not rolled features or explicitly allowed
+        # ``ALLOWED_BASE_NUMERIC_COLS`` now includes contextual stats like
+        # ``team_k_rate`` and ``park_factor`` that should remain in the model
+        # dataset even without rolling windows.
         allowed_numeric = set(StrikeoutModelConfig.ALLOWED_BASE_NUMERIC_COLS)
         target = StrikeoutModelConfig.TARGET_VARIABLE
         keep_cols = []
         for col in df.columns:
-            if pattern.search(col) or col in allowed_numeric or col == target:
+            if pattern.search(col):
+                keep_cols.append(col)
+            elif col in allowed_numeric or col == target:
                 keep_cols.append(col)
             elif not pd.api.types.is_numeric_dtype(df[col]):
                 keep_cols.append(col)

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -134,6 +134,21 @@ def test_log_features_added(tmp_path: Path) -> None:
         assert any(c.startswith("log_") for c in df.columns)
 
 
+def test_base_context_fields_kept(tmp_path: Path) -> None:
+    """Ensure contextual stats like park_factor are retained and transformed."""
+    db_path = setup_test_db(tmp_path)
+
+    engineer_pitcher_features(db_path=db_path)
+    engineer_opponent_features(db_path=db_path)
+    engineer_contextual_features(db_path=db_path)
+    build_model_features(db_path=db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        df = pd.read_sql_query("SELECT * FROM model_features", conn)
+        assert "park_factor" in df.columns
+        assert "log_park_factor" in df.columns
+
+
 def test_rest_days_across_seasons(tmp_path: Path) -> None:
     db_path = setup_test_db(tmp_path, cross_season=True)
 


### PR DESCRIPTION
## Summary
- preserve key numeric context features such as `park_factor` and `team_k_rate`
- adjust join logic to respect the updated allowlist
- test that context stats are retained and transformed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*