### PR TITLE
Update feature engineering tests for additional rolling columns

### DIFF
--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -34,6 +34,7 @@ def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
                 "strikeouts": [5, 6, 7],
                 "pitches": [80, 85, 90],
                 "fip": [4.0, 3.5, 3.0],
+                "slider_pct": [0.2, 0.25, 0.3],
             }
         )
         matchup_df = pitcher_df.copy()
@@ -70,9 +71,15 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert len(df) == 3
         assert any(col == "strikeouts_mean_3" for col in df.columns)
         assert any(col == "fip_mean_3" for col in df.columns)
+        assert "slider_pct_mean_3" in df.columns
+        assert "team_k_rate_mean_3" in df.columns
         assert all("_mean_5" not in c for c in df.columns)
         # ensure raw game stats are dropped
         assert "pitches" not in df.columns
+        assert "fip" not in df.columns
+        assert "slider_pct" not in df.columns
+        assert "team_k_rate" not in df.columns
+        assert "park_factor" not in df.columns
         assert "venue_humidity_mean_3" in df.columns
         assert "venue_park_factor_mean_3" in df.columns
 
@@ -90,6 +97,7 @@ def test_old_window_columns_removed(tmp_path: Path) -> None:
         df = pd.read_sql_query("SELECT * FROM rolling_pitcher_features", conn)
         df["strikeouts_mean_5"] = 1
         df["fip_mean_5"] = 1
+        df["slider_pct_mean_5"] = 1
         df.to_sql("rolling_pitcher_features", conn, if_exists="replace", index=False)
 
     build_model_features(db_path=db_path)


### PR DESCRIPTION
## Summary
- add `slider_pct` field to test fixture
- assert new rolling columns in feature pipeline test
- ensure raw stats are dropped
- adjust unsupported-window test to handle new column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*