### PR TITLE
Improve VIF calculation

### DIFF
--- a/src/features/selection.py
+++ b/src/features/selection.py
@@ -31,9 +31,19 @@ def _calculate_vif(df: pd.DataFrame) -> pd.Series:
     """Return VIF for each column in ``df``."""
     if df.empty:
         return pd.Series(dtype=float)
-    X = df.assign(const=1)
-    vifs = [variance_inflation_factor(X.values, i) for i in range(len(df.columns))]
-    return pd.Series(vifs, index=df.columns)
+
+    # Drop rows with NaN or infinite values to avoid statsmodels errors
+    clean_df = df.replace([np.inf, -np.inf], np.nan).dropna()
+    if clean_df.empty:
+        # Maintain index length even if nothing left after cleaning
+        return pd.Series(np.nan, index=df.columns)
+
+    X = clean_df.assign(const=1)
+    vifs = [
+        variance_inflation_factor(X.values, i) for i in range(len(clean_df.columns))
+    ]
+    series = pd.Series(vifs, index=clean_df.columns)
+    return series.reindex(df.columns)
 
 
 def _prune_vif(df: pd.DataFrame, threshold: float) -> List[str]:


### PR DESCRIPTION
## Summary
- drop rows with NaN/inf values before computing VIF
- return NaN series if all rows are removed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*