### PR TITLE
Fix VIF cleaning logic

### DIFF
--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import numpy as np
+
+from src.features.selection import _calculate_vif
+
+
+def test_calculate_vif_with_nan_and_inf() -> None:
+    df = pd.DataFrame(
+        {
+            "a": [1.0, 2.0, np.nan, np.inf],
+            "b": [np.inf, 1.0, 2.0, np.nan],
+        }
+    )
+    result = _calculate_vif(df)
+    assert list(result.index) == ["a", "b"]
+    assert result.isna().all()
+


### PR DESCRIPTION
## Summary
- update `_calculate_vif` to clean NaNs and infs and return NaN series if empty
- exit `_prune_vif` when VIF series is all NaN
- test handling of NaN/inf data for VIF calculation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*