### PR TITLE
Add LightGBM-based feature pruning

### DIFF
--- a/src/train_model.py
+++ b/src/train_model.py
@@ -54,6 +54,7 @@ def train_lgbm(
         target,
         prune_importance=True,
         importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
+        importance_method="lightgbm",
         prune_vif=True,
         vif_threshold=StrikeoutModelConfig.VIF_THRESHOLD,
     )
@@ -88,6 +89,7 @@ def train_lgbm(
         shap_model=model,
         shap_threshold=StrikeoutModelConfig.SHAP_THRESHOLD,
         shap_sample_frac=StrikeoutModelConfig.SHAP_SAMPLE_FRAC,
+        importance_method="lightgbm",
     )
     if set(shap_features) != set(features) and shap_features:
         features = shap_features

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -21,3 +21,15 @@ def test_prune_feature_importance() -> None:
     cols, imp = _prune_feature_importance(df, target, threshold=0.1)
     assert cols == ["x1"]
     assert imp.loc["x1"] > imp.loc["x2"]
+
+
+def test_prune_feature_importance_lightgbm() -> None:
+    df = pd.DataFrame({"x1": [0, 1, 2, 3, 4], "x2": [1, 1, 1, 1, 1]})
+    target = pd.Series([0, 1, 2, 3, 4])
+    cols, _ = _prune_feature_importance(
+        df,
+        target,
+        threshold=0.1,
+        method="lightgbm",
+    )
+    assert cols == ["x1"]


### PR DESCRIPTION
## Summary
- extend feature selection to support LightGBM-based importance
- use LightGBM for feature pruning in train_model
- cover new feature selection logic in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*