### PR TITLE
Remove VIF and SHAP feature selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ python -m src.scripts.run_feature_engineering --db-path path/to/pitcher_stats.db
 ## Next Steps
 
 * Train baseline model and evaluate performance
-* Explore feature importance using SHAP values
 * Add model monitoring & alerting for production use
 
 ## How to Contribute

--- a/src/config.py
+++ b/src/config.py
@@ -214,9 +214,6 @@ class StrikeoutModelConfig:
     VERBOSE_FIT_FREQUENCY = 20
 
     IMPORTANCE_THRESHOLD = 0.02
-    VIF_THRESHOLD = 7.5
-    SHAP_THRESHOLD = 0.01
-    SHAP_SAMPLE_FRAC = 0.3
 
 class LogConfig:
     # Define Log directory relative to project root

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -49,15 +49,13 @@ def train_lgbm(
     target: str = StrikeoutModelConfig.TARGET_VARIABLE,
 ) -> Tuple[LGBMRegressor, Dict[str, float]]:
     """Train LightGBM model and return the trained model and metrics."""
-    # Initial feature selection with VIF pruning to remove multicollinearity
+    # Select features using tree-based importance
     features, _ = select_features(
         train_df,
         target,
         prune_importance=True,
         importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
         importance_method="lightgbm",
-        prune_vif=True,
-        vif_threshold=StrikeoutModelConfig.VIF_THRESHOLD,
     )
     X_train = train_df[features]
     y_train = train_df[target]
@@ -81,34 +79,6 @@ def train_lgbm(
             lgb.log_evaluation(StrikeoutModelConfig.VERBOSE_FIT_FREQUENCY),
         ],
     )
-
-    # Optionally prune features based on SHAP values and retrain
-    shap_features, _ = select_features(
-        train_df[features + [target]],
-        target,
-        prune_shap=True,
-        shap_model=model,
-        shap_threshold=StrikeoutModelConfig.SHAP_THRESHOLD,
-        shap_sample_frac=StrikeoutModelConfig.SHAP_SAMPLE_FRAC,
-        importance_method="lightgbm",
-    )
-    if set(shap_features) != set(features) and shap_features:
-        features = shap_features
-        X_train = train_df[features]
-        X_test = test_df[features]
-        model = LGBMRegressor(
-            **params,
-            n_estimators=StrikeoutModelConfig.FINAL_ESTIMATORS,
-        )
-        model.fit(
-            X_train,
-            y_train,
-            eval_set=[(X_test, y_test)],
-            callbacks=[
-                lgb.early_stopping(StrikeoutModelConfig.EARLY_STOPPING_ROUNDS),
-                lgb.log_evaluation(StrikeoutModelConfig.VERBOSE_FIT_FREQUENCY),
-            ],
-        )
 
     preds = model.predict(X_test)
     mse = mean_squared_error(y_test, preds)
@@ -137,8 +107,6 @@ def cross_validate_lgbm(
         prune_importance=True,
         importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
         importance_method="lightgbm",
-        prune_vif=True,
-        vif_threshold=StrikeoutModelConfig.VIF_THRESHOLD,
     )
 
     X = df.sort_values("game_date")[features]

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,19 +1,7 @@
 import pandas as pd
-import numpy as np
 
-from src.features.selection import _calculate_vif, _prune_feature_importance
+from src.features.selection import _prune_feature_importance
 
-
-def test_calculate_vif_with_nan_and_inf() -> None:
-    df = pd.DataFrame(
-        {
-            "a": [1.0, 2.0, np.nan, np.inf],
-            "b": [np.inf, 1.0, 2.0, np.nan],
-        }
-    )
-    result = _calculate_vif(df)
-    assert list(result.index) == ["a", "b"]
-    assert result.isna().all()
 
 def test_prune_feature_importance() -> None:
     df = pd.DataFrame({"x1": [0, 1, 2, 3, 4], "x2": [1, 1, 1, 1, 1]})


### PR DESCRIPTION
## Summary
- simplify feature selection to rely solely on tree-based importance
- drop VIF and SHAP pruning logic and config entries
- update training pipeline to use simplified feature selector
- adjust tests accordingly
- update README next steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*