### PR TITLE
Add feature pruning to XGB tuning

### DIFF
--- a/src/tune_xgb.py
+++ b/src/tune_xgb.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Optuna tuning for XGBoost with built-in feature pruning."""
+
 from pathlib import Path
 import json
 from typing import Dict, Optional
@@ -85,7 +87,12 @@ def tune_xgb(
 ) -> Dict[str, float]:
     df = load_dataset(db_path)
     train_df, _ = split_by_year(df)
-    features, _ = select_features(train_df, StrikeoutModelConfig.TARGET_VARIABLE)
+    features, _ = select_features(
+        train_df,
+        StrikeoutModelConfig.TARGET_VARIABLE,
+        prune_importance=True,
+        importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
+    )
     X = train_df[features]
     y = train_df[StrikeoutModelConfig.TARGET_VARIABLE]
 

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from src.features.selection import _prune_feature_importance
+from src.features.selection import _prune_feature_importance, select_features
 
 
 def test_prune_feature_importance() -> None:
@@ -21,3 +21,23 @@ def test_prune_feature_importance_lightgbm() -> None:
         method="lightgbm",
     )
     assert cols == ["x1"]
+
+
+def test_select_features_pruning() -> None:
+    df = pd.DataFrame(
+        {
+            "game_pk": [1, 2, 3, 4, 5],
+            "x1_mean_3": [0, 1, 2, 3, 4],
+            "x2_mean_3": [1, 1, 1, 1, 1],
+            "strikeouts": [0, 1, 2, 3, 4],
+        }
+    )
+    features_no_prune, _ = select_features(df, "strikeouts")
+    assert set(features_no_prune) == {"x1_mean_3", "x2_mean_3"}
+    features, _ = select_features(
+        df,
+        "strikeouts",
+        prune_importance=True,
+        importance_threshold=0.1,
+    )
+    assert features == ["x1_mean_3"]


### PR DESCRIPTION
## Summary
- tune_xgb.py now prunes low-importance features before running Optuna
- extend selection tests to cover full feature pruning path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*