### PR TITLE
Add starting pitcher uniqueness check

### DIFF
--- a/src/data/validate_starting_pitchers.py
+++ b/src/data/validate_starting_pitchers.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+from src.utils import DBConnection
+from src.config import DBConfig
+
+
+def validate_unique_starters(
+    db_path: Path = DBConfig.PATH,
+    table: str = "game_level_starting_pitchers",
+) -> pd.DataFrame:
+    """Return DataFrame of duplicate starters if any are found."""
+    with DBConnection(db_path) as conn:
+        query = (
+            f"SELECT game_pk, pitching_team, COUNT(*) as cnt FROM {table} "
+            "GROUP BY game_pk, pitching_team HAVING COUNT(*) > 1"
+        )
+        dup_df = pd.read_sql_query(query, conn)
+    if dup_df.empty:
+        return dup_df
+    raise ValueError(
+        f"Found multiple starters for {len(dup_df)} game/team combos",
+    )
+
+
+def main() -> None:
+    try:
+        dup_df = validate_unique_starters()
+        if dup_df.empty:
+            print("All teams have exactly one starting pitcher per game.")
+    except ValueError as exc:
+        print(exc)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_validate_starting_pitchers.py
+++ b/tests/test_validate_starting_pitchers.py
@@ -1,0 +1,27 @@
+import sqlite3
+import pandas as pd
+import pytest
+
+from src.data.validate_starting_pitchers import validate_unique_starters
+
+
+def test_validate_unique_starters(tmp_path):
+    db_path = tmp_path / "test.db"
+    with sqlite3.connect(db_path) as conn:
+        df = pd.DataFrame({
+            "game_pk": [1, 1],
+            "pitching_team": ["A", "A"],
+        })
+        df.to_sql("game_level_starting_pitchers", conn, index=False)
+    with pytest.raises(ValueError):
+        validate_unique_starters(db_path=db_path)
+
+    # Replace with unique rows
+    with sqlite3.connect(db_path) as conn:
+        df = pd.DataFrame({
+            "game_pk": [1, 2],
+            "pitching_team": ["A", "B"],
+        })
+        df.to_sql("game_level_starting_pitchers", conn, index=False, if_exists="replace")
+
+    validate_unique_starters(db_path=db_path)


### PR DESCRIPTION
## Summary
- add a helper to verify a single starting pitcher per team in a game
- test the new uniqueness validation logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*