### PR TITLE
Add contextual travel and time features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -153,6 +153,8 @@ class StrikeoutModelConfig:
         "humidity",
         "park_factor",
         "team_k_rate",
+        "day_of_week",
+        "travel_distance",
     ]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -18,6 +18,7 @@ from src.config import (
     StrikeoutModelConfig,
     LogConfig,
     BALLPARK_FACTORS,
+    BALLPARK_COORDS,
 )
 
 logger = setup_logger(
@@ -58,6 +59,22 @@ TEAM_TO_BALLPARK = {
     "TOR": "Rogers Centre",
     "WSH": "Nationals Park",
 }
+
+
+def _haversine_distance(coord1: tuple[float, float] | None,
+                         coord2: tuple[float, float] | None) -> float:
+    """Return great-circle distance in miles between two lat/lon coordinates."""
+    if not coord1 or not coord2:
+        return np.nan
+
+    lat1, lon1 = np.radians(coord1)
+    lat2, lon2 = np.radians(coord2)
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = np.sin(dlat / 2) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(dlon / 2) ** 2
+    c = 2 * np.arcsin(np.sqrt(a))
+    earth_radius_miles = 3958.8
+    return float(earth_radius_miles * c)
 
 
 def _parse_wind_speed(value: str | None) -> float:
@@ -274,6 +291,21 @@ def engineer_contextual_features(
             df["elevation"] = pd.to_numeric(df["elevation"], errors="coerce")
         if "humidity" in df.columns:
             df["humidity"] = pd.to_numeric(df["humidity"], errors="coerce")
+
+        df["day_of_week"] = df["game_date"].dt.dayofweek
+
+        def _compute_distance(row: pd.Series) -> float:
+            if "pitching_team" in row and row["pitching_team"] != row["home_team"]:
+                away = row["pitching_team"]
+            else:
+                away = row.get("opponent_team")
+            home_stadium = TEAM_TO_BALLPARK.get(row["home_team"])
+            away_stadium = TEAM_TO_BALLPARK.get(away)
+            home_coord = BALLPARK_COORDS.get(home_stadium)
+            away_coord = BALLPARK_COORDS.get(away_stadium)
+            return _haversine_distance(away_coord, home_coord)
+
+        df["travel_distance"] = df.apply(_compute_distance, axis=1)
 
         df["stadium"] = df["home_team"].map(TEAM_TO_BALLPARK)
         df["park_factor"] = df["stadium"].map(BALLPARK_FACTORS)

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -85,6 +85,8 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         # encoded categorical columns should be numeric
         assert "home_team_enc" in df.columns
         assert pd.api.types.is_numeric_dtype(df["home_team_enc"])
+        assert "day_of_week" in df.columns
+        assert "travel_distance" in df.columns
 
 
 def test_old_window_columns_removed(tmp_path: Path) -> None:
@@ -158,6 +160,8 @@ def test_base_context_fields_kept(tmp_path: Path) -> None:
         df = pd.read_sql_query("SELECT * FROM model_features", conn)
         assert "park_factor" in df.columns
         assert "log_park_factor" in df.columns
+        assert "day_of_week" in df.columns
+        assert "travel_distance" in df.columns
 
 
 def test_rest_days_across_seasons(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- compute day-of-week and approximate travel distance in contextual features
- keep the new numeric fields in model_features
- test that day_of_week and travel_distance appear in the final dataset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*