### PR TITLE
Add EWM rolling stats

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -105,6 +105,8 @@ class StrikeoutModelConfig:
     # Dramatically smaller windows to keep feature counts manageable
     # Expanded windows to provide more temporal context
     WINDOW_SIZES = [3, 5, 10, 20, 50, 100]
+    # Halflife used for exponentially weighted moving averages
+    EWM_HALFLIFE = 7
     # Limit which numeric columns get rolling stats to avoid huge tables
     PITCHER_ROLLING_COLS = [
         "strikeouts",

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -112,9 +112,9 @@ def _add_group_rolling(
         Restrict calculations to these numeric columns. If ``None`` (default),
         all numeric columns except identifiers are used.
     ewm_halflife : float, optional
-        If provided, additionally compute exponentially weighted means using the
-        specified ``halflife``. The resulting columns are suffixed with
-        ``ewm_<halflife>``.
+        If provided, compute exponentially weighted moving averages using the
+        specified ``halflife``. Columns are suffixed with ``ewm_<halflife>`` and
+        ``momentum_ewm_<halflife>``.
     """
     if windows is None:
         windows = StrikeoutModelConfig.WINDOW_SIZES
@@ -241,6 +241,7 @@ def engineer_opponent_features(
             prefix="opp_",
             n_jobs=n_jobs,
             numeric_cols=StrikeoutModelConfig.CONTEXT_ROLLING_COLS,
+            ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
         )
         if "team_k_rate" in df.columns:
             df = _add_group_rolling(
@@ -250,6 +251,7 @@ def engineer_opponent_features(
                 prefix="team_hand_",
                 n_jobs=n_jobs,
                 numeric_cols=["team_k_rate"],
+                ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
             )
             df = df.drop(columns=["team_k_rate"])
         if rebuild or not table_exists(conn, target_table):
@@ -335,6 +337,7 @@ def engineer_contextual_features(
             prefix="ump_",
             n_jobs=n_jobs,
             numeric_cols=StrikeoutModelConfig.CONTEXT_ROLLING_COLS,
+            ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
         )
         if "weather" in df.columns:
             df = _add_group_rolling(
@@ -344,6 +347,7 @@ def engineer_contextual_features(
                 prefix="wx_",
                 n_jobs=n_jobs,
                 numeric_cols=StrikeoutModelConfig.CONTEXT_ROLLING_COLS,
+                ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
             )
         df = _add_group_rolling(
             df,
@@ -352,6 +356,7 @@ def engineer_contextual_features(
             prefix="venue_",
             n_jobs=n_jobs,
             numeric_cols=StrikeoutModelConfig.CONTEXT_ROLLING_COLS,
+            ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
         )
 
         if rebuild or not table_exists(conn, target_table):

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -66,8 +66,9 @@ def add_rolling_features(
         Limit calculations to these numeric columns. If ``None`` (default), use
         all numeric columns except identifiers.
     ewm_halflife : float, optional
-        If given, additionally compute exponentially weighted means using this
-        ``halflife`` and add ``_ewm_<halflife>`` columns.
+        If provided, also compute exponentially weighted moving averages using
+        ``halflife``. Columns ``<col>_ewm_<halflife>`` and
+        ``<col>_momentum_ewm_<halflife>`` will be appended.
     """
     if windows is None:
         windows = StrikeoutModelConfig.WINDOW_SIZES
@@ -162,6 +163,7 @@ def engineer_pitcher_features(
         date_col="game_date",
         windows=StrikeoutModelConfig.WINDOW_SIZES,
         numeric_cols=StrikeoutModelConfig.PITCHER_ROLLING_COLS,
+        ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
     )
 
     with DBConnection(db_path) as conn:

--- a/src/features/selection.py
+++ b/src/features/selection.py
@@ -95,7 +95,7 @@ def select_features(
         exclude_set.update(exclude_cols)
     exclude_set.add(target_variable)
 
-    pattern = re.compile(r"_(?:mean|std|momentum)_\d+$")
+    pattern = re.compile(r"_(?:mean|std|momentum(?:_ewm)?|ewm)_\d+$")
     allowed_numeric = set(StrikeoutModelConfig.ALLOWED_BASE_NUMERIC_COLS)
 
     numeric_cols = [


### PR DESCRIPTION
## Notes
- Use StrikeoutModelConfig.EWM_HALFLIFE in feature engineering
- Include new EWM columns in feature selection and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*