### PR TITLE
Switch LightGBM to Poisson objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ included for each game.
 3. **Model Training**
 
    * Predict target: strikeouts (`K`) in a game
-   * Model: LightGBM with hyperparameter tuning (`src/tune_lightgbm.py`)
+   * Model: LightGBM using a Poisson objective with hyperparameter tuning (`src/tune_lightgbm.py`)
    * Alternative model: XGBoost (`src/train_xgb_model.py`)
    * Additional model: CatBoost (`src/train_catboost.py`)
    * Evaluation metrics: MAE, RMSE, R^2

--- a/src/config.py
+++ b/src/config.py
@@ -170,6 +170,7 @@ class StrikeoutModelConfig:
 
     # --- LightGBM Hyperparameter Defaults ---
     LGBM_BASE_PARAMS = {
+        'objective': 'poisson',
         'learning_rate': 0.03786686371695319,
         'num_leaves': 82,
         'max_depth': 3,


### PR DESCRIPTION
## Summary
- configure LightGBM to use a Poisson objective
- update docs to mention the Poisson objective

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*