### PR TITLE
Enable feature selection in XGBoost training

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ included for each game.
 
    * Predict target: strikeouts (`K`) in a game
    * Model: LightGBM using a Poisson objective with hyperparameter tuning (`src/tune_lightgbm.py`)
-   * Alternative model: XGBoost (`src/train_xgb_model.py`)
+   * Alternative model: XGBoost (`src/train_xgb_model.py`) with tree-based feature selection
    * Additional model: CatBoost (`src/train_catboost.py`)
    * Evaluation metrics: MAE, RMSE, R^2
 

--- a/src/train_xgb_model.py
+++ b/src/train_xgb_model.py
@@ -26,7 +26,12 @@ def train_xgb(
     test_df: pd.DataFrame,
     target: str = StrikeoutModelConfig.TARGET_VARIABLE,
 ) -> Tuple[XGBRegressor, Dict[str, float]]:
-    features, _ = select_features(train_df, target)
+    features, _ = select_features(
+        train_df,
+        target,
+        prune_importance=True,
+        importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
+    )
     logger.info("Using %d features", len(features))
     X_train = train_df[features]
     y_train = train_df[target]


### PR DESCRIPTION
## Summary
- select features using tree-based importance before training the XGBoost model
- document XGBoost's use of feature selection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*