### PR TITLE
Add chase rate & contact metrics to pitcher features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,47 +9,47 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 # --- Database Schema Constants ---
 # Table Names
-MLB_BOXSCORES_TABLE = 'mlb_boxscores'
-STATCAST_PITCHERS_TABLE = 'statcast_pitchers'
-STATCAST_BATTERS_TABLE = 'statcast_batters'
-STATCAST_STARTING_PITCHERS_TABLE = 'statcast_starting_pitchers'
+MLB_BOXSCORES_TABLE = "mlb_boxscores"
+STATCAST_PITCHERS_TABLE = "statcast_pitchers"
+STATCAST_BATTERS_TABLE = "statcast_batters"
+STATCAST_STARTING_PITCHERS_TABLE = "statcast_starting_pitchers"
 
 
-# Team Mapping Columns 
-TEAM_NAME_MAP_FULL_NAME_COL = 'team_name'
-TEAM_NAME_MAP_ABBR_COL = 'team_abbr'
+# Team Mapping Columns
+TEAM_NAME_MAP_FULL_NAME_COL = "team_name"
+TEAM_NAME_MAP_ABBR_COL = "team_abbr"
 
 BALLPARK_COORDS = {
-    'Chase Field'                   : (33.4455, -112.0667),
-    'Truist Park'                   : (33.8908, -84.4671),
-    'Oriole Park at Camden Yards'   : (39.2839, -76.6217),
-    'Fenway Park'                   : (42.3467, -71.0972),
-    'Wrigley Field'                 : (41.9484, -87.6553),
-    'Guaranteed Rate Field'         : (41.8309, -87.6339),
-    'Great American Ball Park'      : (39.0968, -84.5076),
-    'Progressive Field'             : (41.4954, -81.6850),
-    'Coors Field'                   : (39.7561, -104.9942),
-    'Comerica Park'                 : (42.3390, -83.0485),
-    'Minute Maid Park'              : (29.7571, -95.3557),
-    'Kauffman Stadium'              : (39.0514, -94.4803),
-    'Angel Stadium'                 : (33.8003, -117.8827),
-    'Dodger Stadium'                : (34.0739, -118.2390),
-    'loanDepot Park'                : (25.7781, -80.2197),
-    'American Family Field'         : (43.0283, -87.9717),
-    'Target Field'                  : (44.9817, -93.2772),
-    'Citi Field'                    : (40.7571, -73.8458),
-    'Yankee Stadium'                : (40.8296, -73.9262),
-    'Oakland Coliseum'              : (37.7534, -122.2005),
-    'Citizens Bank Park'            : (39.9057, -75.1664),
-    'PNC Park'                      : (40.4469, -80.0057),
-    'Petco Park'                    : (32.7076, -117.1571),
-    'Oracle Park'                   : (37.7786, -122.3893),
-    'T-Mobile Park'                 : (47.5914, -122.3325),
-    'Busch Stadium'                 : (38.6226, -90.1928),
-    'Tropicana Field'               : (27.7683, -82.6534),
-    'Globe Life Field'              : (32.7510, -97.0828),
-    'Rogers Centre'                 : (43.6414, -79.3894),
-    'Nationals Park'                : (38.8731, -77.0074),
+    "Chase Field": (33.4455, -112.0667),
+    "Truist Park": (33.8908, -84.4671),
+    "Oriole Park at Camden Yards": (39.2839, -76.6217),
+    "Fenway Park": (42.3467, -71.0972),
+    "Wrigley Field": (41.9484, -87.6553),
+    "Guaranteed Rate Field": (41.8309, -87.6339),
+    "Great American Ball Park": (39.0968, -84.5076),
+    "Progressive Field": (41.4954, -81.6850),
+    "Coors Field": (39.7561, -104.9942),
+    "Comerica Park": (42.3390, -83.0485),
+    "Minute Maid Park": (29.7571, -95.3557),
+    "Kauffman Stadium": (39.0514, -94.4803),
+    "Angel Stadium": (33.8003, -117.8827),
+    "Dodger Stadium": (34.0739, -118.2390),
+    "loanDepot Park": (25.7781, -80.2197),
+    "American Family Field": (43.0283, -87.9717),
+    "Target Field": (44.9817, -93.2772),
+    "Citi Field": (40.7571, -73.8458),
+    "Yankee Stadium": (40.8296, -73.9262),
+    "Oakland Coliseum": (37.7534, -122.2005),
+    "Citizens Bank Park": (39.9057, -75.1664),
+    "PNC Park": (40.4469, -80.0057),
+    "Petco Park": (32.7076, -117.1571),
+    "Oracle Park": (37.7786, -122.3893),
+    "T-Mobile Park": (47.5914, -122.3325),
+    "Busch Stadium": (38.6226, -90.1928),
+    "Tropicana Field": (27.7683, -82.6534),
+    "Globe Life Field": (32.7510, -97.0828),
+    "Rogers Centre": (43.6414, -79.3894),
+    "Nationals Park": (38.8731, -77.0074),
 }
 
 # Approximate run-scoring park factors indexed by stadium name. Values above 100
@@ -57,48 +57,51 @@ BALLPARK_COORDS = {
 # pitchers.  These are coarse averages and can be refined when more granular
 # data is available.
 BALLPARK_FACTORS = {
-    'Chase Field'                   : 99,
-    'Truist Park'                   : 101,
-    'Oriole Park at Camden Yards'   : 97,
-    'Fenway Park'                   : 104,
-    'Wrigley Field'                 : 100,
-    'Guaranteed Rate Field'         : 102,
-    'Great American Ball Park'      : 103,
-    'Progressive Field'             : 98,
-    'Coors Field'                   : 115,
-    'Comerica Park'                 : 99,
-    'Minute Maid Park'              : 101,
-    'Kauffman Stadium'              : 98,
-    'Angel Stadium'                 : 99,
-    'Dodger Stadium'                : 100,
-    'loanDepot Park'                : 96,
-    'American Family Field'         : 101,
-    'Target Field'                  : 99,
-    'Citi Field'                    : 98,
-    'Yankee Stadium'                : 103,
-    'Oakland Coliseum'              : 95,
-    'Citizens Bank Park'            : 103,
-    'PNC Park'                      : 97,
-    'Petco Park'                    : 96,
-    'Oracle Park'                   : 95,
-    'T-Mobile Park'                 : 97,
-    'Busch Stadium'                 : 98,
-    'Tropicana Field'               : 97,
-    'Globe Life Field'              : 100,
-    'Rogers Centre'                 : 102,
-    'Nationals Park'                : 100,
+    "Chase Field": 99,
+    "Truist Park": 101,
+    "Oriole Park at Camden Yards": 97,
+    "Fenway Park": 104,
+    "Wrigley Field": 100,
+    "Guaranteed Rate Field": 102,
+    "Great American Ball Park": 103,
+    "Progressive Field": 98,
+    "Coors Field": 115,
+    "Comerica Park": 99,
+    "Minute Maid Park": 101,
+    "Kauffman Stadium": 98,
+    "Angel Stadium": 99,
+    "Dodger Stadium": 100,
+    "loanDepot Park": 96,
+    "American Family Field": 101,
+    "Target Field": 99,
+    "Citi Field": 98,
+    "Yankee Stadium": 103,
+    "Oakland Coliseum": 95,
+    "Citizens Bank Park": 103,
+    "PNC Park": 97,
+    "Petco Park": 96,
+    "Oracle Park": 95,
+    "T-Mobile Park": 97,
+    "Busch Stadium": 98,
+    "Tropicana Field": 97,
+    "Globe Life Field": 100,
+    "Rogers Centre": 102,
+    "Nationals Park": 100,
 }
+
 
 class DBConfig:
     # Use an absolute path so scripts work from any CWD
     PATH = PROJECT_ROOT / "data" / "pitcher_stats.db"
     BATCH_SIZE = 5000
 
+
 class DataConfig:
     SEASONS = [2016, 2017, 2018, 2019, 2021, 2022, 2023, 2024, 2025]
     RATE_LIMIT_PAUSE = 5
     CHUNK_SIZE = 1000000
-    MAX_WORKERS = int(os.getenv('MAX_WORKERS', os.cpu_count() or 1))
+    MAX_WORKERS = int(os.getenv("MAX_WORKERS", os.cpu_count() or 1))
+
 
 class StrikeoutModelConfig:
     RANDOM_STATE = 3
@@ -132,6 +135,14 @@ class StrikeoutModelConfig:
         "avg_release_speed",
         "max_release_speed",
         "avg_spin_rate",
+        "zone_pct",
+        "chase_rate",
+        "avg_launch_speed",
+        "max_launch_speed",
+        "avg_launch_angle",
+        "max_launch_angle",
+        "hard_hit_rate",
+        "barrel_rate",
         "offspeed_to_fastball_ratio",
         "fastball_then_breaking_rate",
         "unique_pitch_types",
@@ -172,16 +183,16 @@ class StrikeoutModelConfig:
 
     # --- LightGBM Hyperparameter Defaults ---
     LGBM_BASE_PARAMS = {
-        'objective': 'poisson',
-        'learning_rate': 0.03786686371695319,
-        'num_leaves': 82,
-        'max_depth': 3,
-        'min_child_samples': 40,
-        'feature_fraction': 0.6561758743969195,
-        'bagging_fraction': 0.6103902823033777,
-        'bagging_freq': 2,
-        'reg_alpha': 0.33907972084342536,
-        'reg_lambda': 8.296994158031719,
+        "objective": "poisson",
+        "learning_rate": 0.03786686371695319,
+        "num_leaves": 82,
+        "max_depth": 3,
+        "min_child_samples": 40,
+        "feature_fraction": 0.6561758743969195,
+        "bagging_fraction": 0.6103902823033777,
+        "bagging_freq": 2,
+        "reg_alpha": 0.33907972084342536,
+        "reg_lambda": 8.296994158031719,
         "seed": RANDOM_STATE,
     }
 
@@ -223,11 +234,11 @@ class StrikeoutModelConfig:
         "loss_function": "RMSE",
         "random_seed": RANDOM_STATE,
         "verbose": False,
-        'depth': 6, 
-        'learning_rate': 0.06653022135887977, 
-        'l2_leaf_reg': 4.1143640300797255, 
-        'bagging_temperature': 0.4708062119340739, 
-        'random_strength': 7.216807176944511
+        "depth": 6,
+        "learning_rate": 0.06653022135887977,
+        "l2_leaf_reg": 4.1143640300797255,
+        "bagging_temperature": 0.4708062119340739,
+        "random_strength": 7.216807176944511,
     }
 
     CATBOOST_PARAM_GRID = {
@@ -248,18 +259,20 @@ class StrikeoutModelConfig:
 
     IMPORTANCE_THRESHOLD = 0.02
 
+
 class LogConfig:
     # Define Log directory relative to project root
-    LOG_DIR = PROJECT_ROOT / 'logs'
+    LOG_DIR = PROJECT_ROOT / "logs"
     # Ensure the directory exists when config is loaded (optional but helpful)
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
+
 class FileConfig:
     # Define Model and Plot directories relative to project root
-    MODELS_DIR = PROJECT_ROOT / 'models'
-    PLOTS_DIR = PROJECT_ROOT / 'plots'
-    DATA_DIR = PROJECT_ROOT / 'data'
-    FEATURE_IMPORTANCE_FILE = MODELS_DIR / 'feature_importance.csv'
+    MODELS_DIR = PROJECT_ROOT / "models"
+    PLOTS_DIR = PROJECT_ROOT / "plots"
+    DATA_DIR = PROJECT_ROOT / "data"
+    FEATURE_IMPORTANCE_FILE = MODELS_DIR / "feature_importance.csv"
     # Ensure these directories exist
     MODELS_DIR.mkdir(parents=True, exist_ok=True)
     PLOTS_DIR.mkdir(parents=True, exist_ok=True)

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -11,6 +11,7 @@ from src.features import (
 from src.features.engineer_features import add_rolling_features
 from src.config import StrikeoutModelConfig
 
+
 def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
     db_path = tmp_path / "test.db"
     with sqlite3.connect(db_path) as conn:
@@ -39,6 +40,14 @@ def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
                 "offspeed_to_fastball_ratio": [0.5, 0.6, 0.55],
                 "fastball_then_breaking_rate": [0.3, 0.4, 0.35],
                 "unique_pitch_types": [3, 4, 3],
+                "zone_pct": [0.5, 0.55, 0.6],
+                "chase_rate": [0.2, 0.25, 0.3],
+                "avg_launch_speed": [89, 90, 91],
+                "max_launch_speed": [99, 100, 101],
+                "avg_launch_angle": [10, 12, 15],
+                "max_launch_angle": [25, 30, 35],
+                "hard_hit_rate": [0.4, 0.45, 0.5],
+                "barrel_rate": [0.1, 0.12, 0.15],
             }
         )
         matchup_df = pitcher_df.copy()
@@ -132,6 +141,7 @@ def test_old_window_columns_removed(tmp_path: Path) -> None:
         df = pd.read_sql_query("SELECT * FROM model_features", conn)
         assert all("_mean_77" not in c for c in df.columns)
 
+
 def test_group_specific_rolling() -> None:
     df = pd.DataFrame(
         {
@@ -153,7 +163,10 @@ def test_group_specific_rolling() -> None:
         ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
     )
     # First row for pitcher 20 should not include pitcher 10 data
-    assert pd.isna(result.loc[2, "strikeouts_mean_3"]) or result.loc[2, "strikeouts_mean_3"] == 0
+    assert (
+        pd.isna(result.loc[2, "strikeouts_mean_3"])
+        or result.loc[2, "strikeouts_mean_3"] == 0
+    )
     assert f"strikeouts_ewm_{StrikeoutModelConfig.EWM_HALFLIFE}" in result.columns
 
 
@@ -200,3 +213,20 @@ def test_rest_days_across_seasons(tmp_path: Path) -> None:
         # Cross-season gap should be calculated correctly
         assert df.loc[1, "rest_days"] == 186
         assert df.loc[2, "rest_days"] == 7
+
+
+def test_new_pitcher_metrics_in_rolling(tmp_path: Path) -> None:
+    db_path = setup_test_db(tmp_path)
+
+    engineer_pitcher_features(db_path=db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        df = pd.read_sql_query("SELECT * FROM rolling_pitcher_features", conn)
+        assert "zone_pct_mean_3" in df.columns
+        assert "chase_rate_mean_3" in df.columns
+        assert "avg_launch_speed_mean_3" in df.columns
+        assert "max_launch_speed_mean_3" in df.columns
+        assert "avg_launch_angle_mean_3" in df.columns
+        assert "max_launch_angle_mean_3" in df.columns
+        assert "hard_hit_rate_mean_3" in df.columns
+        assert "barrel_rate_mean_3" in df.columns


### PR DESCRIPTION
## Summary
- calculate zone pct, chase rate and contact quality metrics when aggregating starting pitchers
- store these new fields when building rolling pitcher features
- include new columns in PITCHER_ROLLING_COLS
- test that rolling features include new contact metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*