### PR TITLE
Broaden numeric feature retention

### DIFF
--- a/src/features/join.py
+++ b/src/features/join.py
@@ -125,20 +125,12 @@ def build_model_features(
         if drop_cols:
             df = df.drop(columns=drop_cols)
 
-        # Remove numeric columns that are not rolled features or explicitly allowed
-        # ``ALLOWED_BASE_NUMERIC_COLS`` now includes contextual stats like
-        # ``team_k_rate`` and ``park_factor`` that should remain in the model
-        # dataset even without rolling windows.
-        allowed_numeric = set(StrikeoutModelConfig.ALLOWED_BASE_NUMERIC_COLS)
+        # Retain all columns after dropping unsupported window sizes. Previously
+        # numeric columns that weren't rolled or explicitly listed in
+        # ``ALLOWED_BASE_NUMERIC_COLS`` were discarded.  Keeping them allows the
+        # model to consider raw game statistics as well.
         target = StrikeoutModelConfig.TARGET_VARIABLE
-        keep_cols = []
-        for col in df.columns:
-            if pattern.search(col):
-                keep_cols.append(col)
-            elif col in allowed_numeric or col == target:
-                keep_cols.append(col)
-            elif not pd.api.types.is_numeric_dtype(df[col]):
-                keep_cols.append(col)
+        keep_cols = list(df.columns)
         df = df[keep_cols]
 
         numeric_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c]) and c != target]

--- a/src/features/selection.py
+++ b/src/features/selection.py
@@ -8,8 +8,6 @@ pruned using tree-based model importances.
 from __future__ import annotations
 
 from typing import Iterable, List, Optional, Tuple
-
-import re
 from lightgbm import LGBMRegressor
 from sklearn.ensemble import ExtraTreesRegressor
 
@@ -95,15 +93,13 @@ def select_features(
         exclude_set.update(exclude_cols)
     exclude_set.add(target_variable)
 
-    pattern = re.compile(r"_(?:mean|std|momentum(?:_ewm)?|ewm)_\d+$")
-    allowed_numeric = set(StrikeoutModelConfig.ALLOWED_BASE_NUMERIC_COLS)
-
+    # Consider every numeric column that isn't explicitly excluded. Previous
+    # versions limited this to rolled features or those in
+    # ``ALLOWED_BASE_NUMERIC_COLS``.
     numeric_cols = [
         c
         for c in df.columns
-        if c not in exclude_set
-        and pd.api.types.is_numeric_dtype(df[c])
-        and (pattern.search(c) or c in allowed_numeric)
+        if c not in exclude_set and pd.api.types.is_numeric_dtype(df[c])
     ]
     selected = numeric_cols
 

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -122,12 +122,15 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert f"strikeouts_ewm_{halflife}" in df.columns
         assert f"strikeouts_momentum_ewm_{halflife}" in df.columns
         assert all("_mean_77" not in c for c in df.columns)
-        # ensure raw game stats are dropped
-        assert "pitches" not in df.columns
-        assert "fip" not in df.columns
-        assert "slider_pct" not in df.columns
-        assert "team_k_rate" not in df.columns
-        assert "park_factor" not in df.columns
+        # raw game stats should be retained
+        assert "pitches" in df.columns
+        assert "fip" in df.columns
+        assert "slider_pct" in df.columns
+        assert "team_k_rate" in df.columns
+        assert "park_factor" in df.columns
+        assert "log_fip" in df.columns
+        assert "log_pitches" in df.columns
+        assert "log_park_factor" in df.columns
         assert "venue_humidity_mean_3" in df.columns
         assert "venue_park_factor_mean_3" in df.columns
         # encoded categorical columns should be numeric

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -41,3 +41,17 @@ def test_select_features_pruning() -> None:
         importance_threshold=0.1,
     )
     assert features == ["x1_mean_3"]
+
+
+def test_select_features_includes_base_numeric() -> None:
+    """Numeric columns that aren't rolled should still be selected."""
+    df = pd.DataFrame(
+        {
+            "game_pk": [1, 2, 3],
+            "pitches": [80, 90, 100],
+            "pitches_mean_3": [80, 85, 90],
+            "strikeouts": [1, 2, 3],
+        }
+    )
+    features, _ = select_features(df, "strikeouts")
+    assert set(features) == {"pitches", "pitches_mean_3"}


### PR DESCRIPTION
## Summary
- keep all numeric columns when building model features
- select any numeric column not explicitly excluded
- update tests for broader numeric set and add coverage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683ab8c514808331a220fe5088fcde14