### PR TITLE
Fix encoding leakage for pitcher id columns

### DIFF
--- a/src/features/join.py
+++ b/src/features/join.py
@@ -8,6 +8,13 @@ from src.utils import table_exists, get_latest_date
 from src.config import DBConfig, LogConfig, StrikeoutModelConfig
 from .encoding import mean_target_encode
 from .selection import BASE_EXCLUDE_COLS
+
+# Categorical columns that should be ignored when mean target encoding
+EXTRA_CAT_EXCLUDE_COLS = [
+    "away_pitcher_ids",
+    "home_pitcher_ids",
+    "scraped_timestamp",
+]
 import re
 import numpy as np
 
@@ -136,15 +143,28 @@ def build_model_features(
         numeric_cols = [c for c in df.columns if pd.api.types.is_numeric_dtype(df[c]) and c != target]
         _winsorize_columns(df, numeric_cols)
         _log_transform(df, numeric_cols)
+        exclude_set = set(BASE_EXCLUDE_COLS).union(EXTRA_CAT_EXCLUDE_COLS)
         cat_cols = [
             c
             for c in df.columns
-            if c not in BASE_EXCLUDE_COLS
+            if c not in exclude_set
             and not pd.api.types.is_numeric_dtype(df[c])
             and c != target
         ]
         if cat_cols:
-            df, _ = mean_target_encode(df, cat_cols, target)
+            train_mask = df["game_date"].dt.year.isin(
+                StrikeoutModelConfig.DEFAULT_TRAIN_YEARS
+            )
+            if not train_mask.any() or not (~train_mask).any():
+                df, _ = mean_target_encode(df, cat_cols, target)
+            else:
+                train_df, enc_map = mean_target_encode(
+                    df.loc[train_mask], cat_cols, target
+                )
+                test_df, _ = mean_target_encode(
+                    df.loc[~train_mask], cat_cols, mapping=enc_map
+                )
+                df = pd.concat([train_df, test_df]).sort_index()
         if df.empty:
             logger.info("No new rows to process for %s", target_table)
             return df

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -289,3 +289,29 @@ def test_run_feature_engineering_script(tmp_path: Path) -> None:
         assert "lineup_avg_ops_mean_3" in lineup_cols
         model_cols = [row[1] for row in conn.execute("PRAGMA table_info(model_features)")]
         assert "lineup_avg_ops_mean_3" in model_cols
+
+
+def test_extra_cat_cols_excluded(tmp_path: Path) -> None:
+    """Ensure problematic categorical columns are not mean-encoded."""
+    db_path = setup_test_db(tmp_path)
+
+    engineer_pitcher_features(db_path=db_path)
+    engineer_opponent_features(db_path=db_path)
+    engineer_contextual_features(db_path=db_path)
+
+    # Inject columns that should not be encoded
+    with sqlite3.connect(db_path) as conn:
+        df = pd.read_sql_query("SELECT * FROM contextual_features", conn)
+        df["away_pitcher_ids"] = ["[1]"] * len(df)
+        df["home_pitcher_ids"] = ["[2]"] * len(df)
+        df["scraped_timestamp"] = "2024-04-01"
+        df.to_sql("contextual_features", conn, if_exists="replace", index=False)
+
+    engineer_lineup_trends(db_path=db_path)
+    build_model_features(db_path=db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        df = pd.read_sql_query("SELECT * FROM model_features", conn)
+        assert "away_pitcher_ids_enc" not in df.columns
+        assert "home_pitcher_ids_enc" not in df.columns
+        assert "scraped_timestamp_enc" not in df.columns


### PR DESCRIPTION
## Summary
- ignore scraped ID columns when building features
- compute mean encoding using training years only to prevent leakage
- add regression test for ignoring unwanted columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683b22e98f1483318b691b444f4726b9