### PR TITLE
Add lineup scraping and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This project builds a machine learning pipeline to predict the number of strikeo
 
 The project follows these main steps:
 
-1.  **Data Fetching:** Retrieves raw data (Statcast, schedules, team stats, umpire assignments) using `pybaseball` and web scraping (ESPN).
+1.  **Data Fetching:** Retrieves raw data (Statcast, schedules, team stats, umpire assignments) using `pybaseball`, scrapes starting lineups from the MLB Stats API, and also scrapes umpires from ESPN.
 2.  **Data Aggregation:** Processes pitch-level Statcast data into game-level summaries for pitchers and batters.
-3.  **Feature Engineering:** Calculates numerous features based on historical performance, including rolling averages for pitchers, opponents, ballparks, and umpires, as well as pitcher rest days.
+3.  **Feature Engineering:** Calculates numerous features based on historical performance, including rolling averages for pitchers, opponents, ballparks, umpires, and aggregated lineup metrics, as well as pitcher rest days.
 4.  **Model Training:** Trains a LightGBM model (using Poisson regression) on the historical features, incorporating feature selection and hyperparameter tuning (Optuna).
 5.  **Prediction:** Uses the trained model and newly generated features to predict strikeouts for upcoming games.
 
@@ -67,7 +67,7 @@ mlb_pred/
 4.  **Configure:**
     * Edit `src/config.py` to set the correct database path (`DB_PATH`), potentially update API keys or placeholders, and review feature lists/parameters.
     * Ensure necessary drivers (like ChromeDriver for Selenium) are installed and accessible if running scraping scripts locally.
-5.  **Database:** The pipeline uses an SQLite database (`mlb_data.db` by default, as defined in `config.py`). The initial data fetching step will create and populate this database.
+5.  **Database:** The pipeline uses an SQLite database (`mlb_data.db` by default, as defined in `config.py`). The initial data fetching step will create and populate this database, including a `daily_lineups` table with each game's starting lineup.
 
 ## Usage
 

--- a/src/features/lineup_features.py
+++ b/src/features/lineup_features.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import logging
+from typing import Callable, List, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_batter_rolling_features(
+    batter_hist_df: pd.DataFrame,
+    group_col: str,
+    date_col: str,
+    metrics: List[str],
+    windows: List[int],
+    min_periods: int,
+    calculate_multi_window_rolling: Callable,
+) -> (pd.DataFrame, Dict[str, str]):
+    """Calculate rolling stats for batters."""
+    if batter_hist_df is None or batter_hist_df.empty:
+        logger.warning("Batter history DataFrame is empty.")
+        return pd.DataFrame(), {}
+
+    available_metrics = [m for m in metrics if m in batter_hist_df.columns]
+    if not available_metrics:
+        logger.warning("No batter metrics found for rolling calculation.")
+        return pd.DataFrame(), {}
+
+    rolling_df = calculate_multi_window_rolling(
+        df=batter_hist_df,
+        group_col=group_col,
+        date_col=date_col,
+        metrics=available_metrics,
+        windows=windows,
+        min_periods=min_periods,
+    )
+
+    rename_map = {
+        f"{m}_roll{w}g": f"b_roll{w}g_{m}"
+        for w in windows
+        for m in available_metrics
+        if f"{m}_roll{w}g" in rolling_df.columns
+    }
+    rolling_df = rolling_df.rename(columns=rename_map)
+    rolling_df[group_col] = batter_hist_df[group_col]
+    rolling_df[date_col] = batter_hist_df[date_col]
+    return rolling_df, rename_map
+
+
+def aggregate_lineup_metrics(
+    lineup_df: pd.DataFrame,
+    batter_rolling_df: pd.DataFrame,
+    windows: List[int],
+) -> pd.DataFrame:
+    """Aggregate batter rolling metrics across a starting lineup."""
+    if lineup_df is None or lineup_df.empty or batter_rolling_df is None or batter_rolling_df.empty:
+        logger.warning("Lineup or batter rolling data empty; skipping aggregation.")
+        return pd.DataFrame()
+
+    merge_cols = ["batter_id", "game_date"]
+    merged = pd.merge(lineup_df, batter_rolling_df, on=merge_cols, how="left")
+
+    grouped = merged.groupby(["game_pk", "team_abbr"])
+    frames = []
+    for w in windows:
+        cols = [c for c in batter_rolling_df.columns if c.startswith(f"b_roll{w}g_")]
+        if not cols:
+            continue
+        agg = grouped[cols].mean()
+        rename = {}
+        for c in cols:
+            base = c.replace(f"b_roll{w}g_", "")
+            if base.endswith("_bat"):
+                base = base[:-4]
+            rename[c] = f"lineup_{base}_mean_roll{w}g"
+        frames.append(agg.rename(columns=rename))
+
+    if not frames:
+        logger.warning("No lineup metrics calculated.")
+        return pd.DataFrame()
+
+    return pd.concat(frames, axis=1).reset_index()

--- a/src/scripts/generate_features.py
+++ b/src/scripts/generate_features.py
@@ -43,6 +43,10 @@ try:
         merge_ballpark_features_prediction,
     )
     from src.features.umpire_features import calculate_umpire_rolling_features
+    from src.features.lineup_features import (
+        calculate_batter_rolling_features,
+        aggregate_lineup_metrics,
+    )
 
     MODULE_IMPORTS_OK = True
 except ImportError as e:
@@ -86,6 +90,16 @@ OPPONENT_METRICS_FOR_ROLLING = [
     "hard_hit_percent",
     "barrel_percent",
     # Add _vs_LHP/_vs_RHP if available in game_level_team_stats
+]
+BATTER_METRICS_FOR_ROLLING = [
+    "k_percent_bat",
+    "bb_percent_bat",
+    "woba_bat",
+    "iso_bat",
+    "babip_bat",
+    "hard_hit_percent",
+    "barrel_percent",
+    "hr_per_pa",
 ]
 BALLPARK_METRICS_FOR_ROLLING = ["k_percent"]  # Based on pitcher (starter) k_percent
 UMPIRE_METRICS_FOR_ROLLING = ["k_percent"]  # Based on pitcher (starter) k_percent
@@ -379,6 +393,33 @@ def generate_features(
     )
     # <<< END TEAM HISTORY LOAD ---
 
+    # --- Load Batter History for Lineup Features ---
+    batter_stats_table = "game_level_batters"
+    try:
+        with DBConnection() as conn:
+            batter_cols_avail = pd.read_sql_query(
+                f"SELECT * FROM {batter_stats_table} LIMIT 1", conn
+            ).columns.tolist()
+    except Exception as e:
+        logger.warning(f"Cannot read columns from {batter_stats_table}: {e}")
+        batter_cols_avail = []
+
+    batter_metrics_to_use = [m for m in BATTER_METRICS_FOR_ROLLING if m in batter_cols_avail]
+    batter_base_cols = ["batter", "game_date", "game_pk", "team"]
+    batter_cols_to_load = list(set(batter_base_cols) | set(batter_metrics_to_use))
+    batter_cols_to_load_str = ", ".join([f'"{c}"' for c in batter_cols_to_load if c in batter_cols_avail])
+    batter_hist_df = (
+        load_data_from_db(
+            f"SELECT {batter_cols_to_load_str} FROM {batter_stats_table} WHERE DATE(game_date) <= '{max_hist_date_str}'",
+            db_path,
+        )
+        if batter_cols_to_load_str
+        else pd.DataFrame()
+    )
+
+    lineup_table = "daily_lineups"
+    lineup_df = load_data_from_db(f"SELECT * FROM {lineup_table}", db_path, optimize=False)
+
     # --- Load Historical Umpire Data (No Change Here) ---
     umpire_table = "historical_umpire_data"
     umpire_cols_to_load = [
@@ -406,6 +447,9 @@ def generate_features(
             f"Team history empty (loaded from {team_stats_table}). Opponent features will be limited."
         )
 
+    if batter_hist_df.empty:
+        logger.warning(f"Batter history empty (loaded from {batter_stats_table}). Lineup features will be limited.")
+
     # Convert dates AFTER loading all data
     logger.info("Converting date columns...")
     pitcher_hist_df["game_date"] = pd.to_datetime(pitcher_hist_df["game_date"])
@@ -413,6 +457,17 @@ def generate_features(
         team_hist_df["game_date"] = pd.to_datetime(team_hist_df["game_date"])
     if not umpire_hist_df.empty:
         umpire_hist_df["game_date"] = pd.to_datetime(umpire_hist_df["game_date"])
+    if not batter_hist_df.empty:
+        batter_hist_df["game_date"] = pd.to_datetime(batter_hist_df["game_date"])
+        batter_hist_df = batter_hist_df.rename(columns={"batter": "batter_id", "team": "team_abbr"})
+    if not lineup_df.empty:
+        lineup_df = lineup_df.rename(columns={"batter_id": "batter_id"})
+        lineup_df = pd.merge(
+            lineup_df,
+            pitcher_hist_df[["game_pk", "game_date"]].drop_duplicates(),
+            on="game_pk",
+            how="left",
+        )
 
     # Add 'is_home' derived column to pitcher_hist_df (STARTER BASED)
     if "team" in pitcher_hist_df.columns and "home_team" in pitcher_hist_df.columns:
@@ -616,6 +671,32 @@ def generate_features(
     all_rolling_features["umpire"] = umpire_rolling_df
     all_rename_maps["umpire"] = ump_rename_map
 
+    # Batter Rolling Features
+    batter_rolling_df = pd.DataFrame()
+    if not batter_hist_df.empty:
+        batter_metrics_avail = [m for m in BATTER_METRICS_FOR_ROLLING if m in batter_hist_df.columns]
+        batter_rolling_df, bat_rename_map = calculate_batter_rolling_features(
+            batter_hist_df=batter_hist_df,
+            group_col="batter_id",
+            date_col="game_date",
+            metrics=batter_metrics_avail,
+            windows=ROLLING_WINDOWS,
+            min_periods=MIN_ROLLING_PERIODS,
+            calculate_multi_window_rolling=calculate_multi_window_rolling,
+        )
+        all_rolling_features["batter"] = batter_rolling_df
+        all_rename_maps["batter"] = bat_rename_map
+
+    # Lineup Aggregates
+    lineup_features_df = pd.DataFrame()
+    if not lineup_df.empty and not batter_rolling_df.empty:
+        lineup_features_df = aggregate_lineup_metrics(
+            lineup_df=lineup_df,
+            batter_rolling_df=batter_rolling_df,
+            windows=ROLLING_WINDOWS,
+        )
+        all_rolling_features["lineup"] = lineup_features_df
+
     logger.info(
         f"Feature calculation finished in {(datetime.now() - calc_start_time).total_seconds():.2f}s."
     )
@@ -721,6 +802,17 @@ def generate_features(
                 bpark_rename_map=all_rename_maps["ballpark"],
             )  # merge_ballpark_features_historical needs 'ballpark' column
 
+        # Merge Lineup features
+        if "lineup" in all_rolling_features and not all_rolling_features["lineup"].empty:
+            final_features_df = pd.merge(
+                final_features_df,
+                all_rolling_features["lineup"],
+                left_on=["game_pk", "opponent_team"],
+                right_on=["game_pk", "team_abbr"],
+                how="left",
+            ).drop(columns=["team_abbr"], errors="ignore")
+            logger.debug("Merged lineup features for historical games.")
+        
         # Merge Umpire features (derived from starter pitcher stats & umpire hist)
         if (
             "umpire" in all_rolling_features
@@ -894,6 +986,16 @@ def generate_features(
             else pd.DataFrame()
         )
 
+        latest_batter_rolling = (
+            all_rolling_features.get("batter", pd.DataFrame())
+        )
+        if not latest_batter_rolling.empty:
+            latest_batter_rolling = latest_batter_rolling[
+                latest_batter_rolling["game_date"] <= prediction_date_str
+            ].sort_values("game_date").drop_duplicates(
+                subset=["batter_id"], keep="last"
+            )
+
         # Add keys back for merging
         if not latest_pitcher_rolling.empty:
             latest_pitcher_rolling["pitcher_id"] = pitcher_hist_df.loc[
@@ -1050,6 +1152,32 @@ def generate_features(
         else:
             logger.warning("Umpire rename map or latest umpire rolling data missing.")
 
+        # Lineup Features for prediction date
+        lineup_pred_df = pd.DataFrame()
+        if not lineup_df.empty and not latest_batter_rolling.empty:
+            pred_lineups = lineup_df[lineup_df["game_pk"].isin(final_features_df["game_pk"])]
+            pred_lineups = pred_lineups.copy()
+            pred_lineups["game_date"] = prediction_date_str
+            lineup_pred_df = aggregate_lineup_metrics(
+                lineup_df=pred_lineups,
+                batter_rolling_df=latest_batter_rolling,
+                windows=ROLLING_WINDOWS,
+            )
+        if not lineup_pred_df.empty:
+            final_features_df = pd.merge(
+                final_features_df,
+                lineup_pred_df,
+                left_on=["game_pk", "opponent_team"],
+                right_on=["game_pk", "team_abbr"],
+                how="left",
+            ).drop(columns=["team_abbr"], errors="ignore")
+        else:
+            for w in ROLLING_WINDOWS:
+                for m in BATTER_METRICS_FOR_ROLLING:
+                    col = f"lineup_{m.replace('_bat','')}_mean_roll{w}g"
+                    if col not in final_features_df.columns:
+                        final_features_df[col] = np.nan
+
         # Format date back to string for saving
         final_features_df["game_date"] = final_features_df["game_date"].dt.strftime(
             "%Y-%m-%d"
@@ -1086,6 +1214,11 @@ def generate_features(
     expected_opp_roll_cols_base = list(all_rename_maps.get("opponent", {}).values())
     expected_bp_roll_cols = list(all_rename_maps.get("ballpark", {}).values())
     expected_ump_roll_cols = list(all_rename_maps.get("umpire", {}).values())
+    expected_lineup_cols = [
+        col
+        for col in all_rolling_features.get("lineup", pd.DataFrame()).columns
+        if col not in ["game_pk", "team_abbr"]
+    ]
 
     # Adjust opponent cols based on prediction mode logic (no change needed here)
     if mode == "PREDICTION":
@@ -1116,6 +1249,7 @@ def generate_features(
             + expected_opp_roll_cols
             + expected_bp_roll_cols
             + expected_ump_roll_cols
+            + expected_lineup_cols
         )
     )
 
@@ -1139,6 +1273,7 @@ def generate_features(
         expected_opp_roll_cols,
         expected_bp_roll_cols,
         expected_ump_roll_cols,
+        expected_lineup_cols,
     ]:
         for col in col_list:
             if col in expected_cols:


### PR DESCRIPTION
## Summary
- scrape daily lineups from Stats API
- store daily lineups when fetching data
- compute lineup-level rolling metrics from batter data
- merge lineup features into training and prediction datasets
- document the new table and features

## Testing
- `python -m py_compile src/data/mlb_api.py src/scripts/data_fetcher.py src/scripts/generate_features.py src/features/lineup_features.py`

------
https://chatgpt.com/codex/tasks/task_e_683ca5df505c8331867b67c9c6195a08