### PR TITLE
Expose VIF and SHAP thresholds in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Run the scripts in the following order. Use command-line arguments where applica
 
 4.  **Train Model:**
     ```bash
-    python src/models/train_lgb_model.py --training_end_date YYYY-MM-DD
+    python src/models/train_lgb_model.py --training_end_date YYYY-MM-DD \
+        --vif-threshold 10 --shap-threshold 0.001
     ```
     *(This will train on data up to the specified end date)*
 


### PR DESCRIPTION
## Summary
- expose `--vif-threshold` and `--shap-threshold` in `train_lgb_model.py`
- pass provided thresholds to `select_features`
- document new CLI options in the README

## Testing
- `python -m py_compile src/models/train_lgb_model.py src/features/selection.py`

------
https://chatgpt.com/codex/tasks/task_e_683ca677da248331b020e9fd8846e61a