### PR TITLE
Add baseline prediction and evaluation script

### DIFF
--- a/src/models/baseline.py
+++ b/src/models/baseline.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import numpy as np
+
+
+def recent_average_predict(train_df: pd.DataFrame,
+                            test_df: pd.DataFrame,
+                            pitcher_col: str = "pitcher_id",
+                            date_col: str = "game_date",
+                            target_col: str = "strikeouts",
+                            window: int = 5) -> pd.Series:
+    """Predict strikeouts using the mean of a pitcher's previous games.
+
+    Parameters
+    ----------
+    train_df : pd.DataFrame
+        Historical training data containing the target column.
+    test_df : pd.DataFrame
+        Test data for which predictions are required.
+    pitcher_col : str
+        Column identifying the pitcher.
+    date_col : str
+        Column with game dates.
+    target_col : str
+        Column with strikeout totals.
+    window : int
+        Number of prior games to average.
+
+    Returns
+    -------
+    pd.Series
+        Baseline predictions aligned to ``test_df`` index.
+    """
+    if train_df is None or test_df is None:
+        return pd.Series(dtype=float)
+
+    # Work on copies to avoid modifying original frames
+    train_df = train_df[[pitcher_col, date_col, target_col]].copy()
+    test_df = test_df[[pitcher_col, date_col, target_col]].copy()
+
+    train_df["__dataset__"] = "train"
+    test_df["__dataset__"] = "test"
+    train_df["_orig_index"] = train_df.index
+    test_df["_orig_index"] = test_df.index
+
+    combined = pd.concat([train_df, test_df], ignore_index=True)
+    combined[date_col] = pd.to_datetime(combined[date_col])
+    combined = combined.sort_values([pitcher_col, date_col])
+
+    rolling = (
+        combined.groupby(pitcher_col)[target_col]
+        .apply(lambda s: s.shift(1).rolling(window=window, min_periods=1).mean())
+        .reset_index(level=0, drop=True)
+    )
+
+    combined["baseline_pred"] = rolling
+
+    preds = (
+        combined[combined["__dataset__"] == "test"]
+        .set_index("_orig_index")["baseline_pred"]
+        .sort_index()
+    )
+    return preds
+

--- a/src/scripts/evaluate_baseline.py
+++ b/src/scripts/evaluate_baseline.py
@@ -1,0 +1,82 @@
+import argparse
+import pickle
+import logging
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+import lightgbm as lgb
+from sklearn.metrics import mean_squared_error, mean_absolute_error
+
+from src.config import DBConfig, FileConfig, LogConfig
+from src.data.utils import DBConnection, setup_logger, find_latest_file
+from src.models.baseline import recent_average_predict
+
+
+def within_n_strikeouts(y_true, y_pred, n=1):
+    if y_true is None or y_pred is None or len(y_true) != len(y_pred):
+        return np.nan
+    y_true_arr = np.asarray(y_true)
+    y_pred_arr = np.asarray(y_pred)
+    return np.mean(np.abs(y_true_arr - np.round(y_pred_arr)) <= n)
+
+
+def load_data(db_path: Path):
+    with DBConnection(db_path) as conn:
+        train_df = pd.read_sql_query("SELECT * FROM train_features", conn)
+        test_df = pd.read_sql_query("SELECT * FROM test_features", conn)
+    return train_df, test_df
+
+
+def evaluate_baseline(window: int, model_prefix: str):
+    logger = setup_logger("evaluate_baseline", LogConfig.LOG_DIR / "evaluate_baseline.log")
+    db_path = Path(DBConfig.PATH)
+    train_df, test_df = load_data(db_path)
+    if train_df.empty or test_df.empty:
+        logger.error("Training or test data could not be loaded from database.")
+        return
+
+    preds = recent_average_predict(train_df, test_df, window=window)
+    y_true = test_df["strikeouts"].values
+
+    rmse = np.sqrt(mean_squared_error(y_true, preds))
+    mae = mean_absolute_error(y_true, preds)
+    w1 = within_n_strikeouts(y_true, preds, n=1)
+    logger.info(f"Baseline RMSE: {rmse:.4f}, MAE: {mae:.4f}, within_1_so: {w1:.4f}")
+
+    # Attempt LightGBM comparison
+    model_dir = Path(FileConfig.MODELS_DIR)
+    model_path = find_latest_file(model_dir, f"{model_prefix}_strikeout_model_*.txt")
+    feature_path = find_latest_file(model_dir, f"{model_prefix}_feature_columns_*.pkl")
+    if model_path and feature_path:
+        logger.info(f"Loading LightGBM model from {model_path}")
+        model = lgb.Booster(model_file=str(model_path))
+        with open(feature_path, "rb") as f:
+            feature_cols = pickle.load(f)
+        missing = [f for f in feature_cols if f not in test_df.columns]
+        if missing:
+            logger.error(f"Test data missing required features for LGBM: {missing}")
+            return
+        lgb_preds = model.predict(test_df[feature_cols])
+        lgb_rmse = np.sqrt(mean_squared_error(y_true, lgb_preds))
+        lgb_mae = mean_absolute_error(y_true, lgb_preds)
+        lgb_w1 = within_n_strikeouts(y_true, lgb_preds, n=1)
+        logger.info(
+            f"LightGBM RMSE: {lgb_rmse:.4f}, MAE: {lgb_mae:.4f}, within_1_so: {lgb_w1:.4f}"
+        )
+        logger.info(f"RMSE improvement vs baseline: {rmse - lgb_rmse:+.4f}")
+        logger.info(f"MAE improvement vs baseline: {mae - lgb_mae:+.4f}")
+        logger.info(f"Within_1_so improvement: {lgb_w1 - w1:+.4f}")
+    else:
+        logger.warning("LightGBM artifacts not found; skipping comparison.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Evaluate recent-average baseline")
+    parser.add_argument("--window", type=int, default=5, help="Number of games for average")
+    parser.add_argument(
+        "--model-prefix", type=str, default="test_lgb", help="Prefix for LGBM artifacts"
+    )
+    args = parser.parse_args()
+    evaluate_baseline(window=args.window, model_prefix=args.model_prefix)
+


### PR DESCRIPTION
## Summary
- add a simple recent-average baseline model
- add script to evaluate the baseline and compare with LightGBM metrics

## Testing
- `python -m py_compile src/models/baseline.py src/scripts/evaluate_baseline.py`

------
https://chatgpt.com/codex/tasks/task_e_683ca67839d883318a0c92580961dcfd