### PR TITLE
Add pitch movement features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -142,6 +142,11 @@ class StrikeoutModelConfig:
         "offspeed_to_fastball_ratio",
         "fastball_then_breaking_rate",
         "unique_pitch_types",
+        "pfx_x",
+        "pfx_z",
+        "release_extension",
+        "plate_x",
+        "plate_z",
     ]
     CONTEXT_ROLLING_COLS = [
         "strikeouts",

--- a/src/data/create_starting_pitcher_table.py
+++ b/src/data/create_starting_pitcher_table.py
@@ -176,6 +176,13 @@ def compute_features(df: pd.DataFrame) -> Dict:
         "max_launch_angle": max_launch_angle,
         "hard_hit_rate": hard_hit_rate,
         "barrel_rate": barrel_rate,
+        "pfx_x": df["pfx_x"].mean() if "pfx_x" in df.columns else np.nan,
+        "pfx_z": df["pfx_z"].mean() if "pfx_z" in df.columns else np.nan,
+        "release_extension": df["release_extension"].mean()
+        if "release_extension" in df.columns
+        else np.nan,
+        "plate_x": df["plate_x"].mean() if "plate_x" in df.columns else np.nan,
+        "plate_z": df["plate_z"].mean() if "plate_z" in df.columns else np.nan,
         # FIP formula without constant: (13*HR + 3*(BB+HBP) - 2*K) / IP
         "fip": (
             (

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -53,6 +53,11 @@ def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
                 "max_launch_angle": [25, 30, 35],
                 "hard_hit_rate": [0.4, 0.45, 0.5],
                 "barrel_rate": [0.1, 0.12, 0.15],
+                "pfx_x": [0.1, 0.2, 0.15],
+                "pfx_z": [-0.5, -0.6, -0.4],
+                "release_extension": [6.0, 6.1, 6.2],
+                "plate_x": [-0.2, -0.3, -0.1],
+                "plate_z": [2.5, 2.6, 2.7],
             }
         )
         matchup_df = pitcher_df.copy()
@@ -112,6 +117,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert "unique_pitch_types_mean_3" in df.columns
         assert "zone_pct_mean_3" in df.columns
         assert "hard_hit_rate_mean_3" in df.columns
+        assert "pfx_x_mean_3" in df.columns
         assert "lineup_avg_ops_mean_3" in df.columns
         assert "team_k_rate_mean_3" in df.columns
         assert "opp_lineup_woba_mean_3" in df.columns


### PR DESCRIPTION
## Summary
- compute mean movement metrics when aggregating starting pitcher stats
- roll new movement features in engineer_pitcher_features
- include movement stats in unit test setup and checks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cb18c9b6083319a4797f01b4a58f7