### PR TITLE
Add catcher defense metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Includes metadata for each game such as:
 Starting lineups pulled from the MLB boxscore endpoint.
 
 ```text
-['game_pk', 'team', 'batter_id', 'batting_order', 'stand']
+['game_pk', 'team', 'batter_id', 'batting_order', 'stand', 'catcher_id']
 ```
 
 

--- a/src/data/create_catcher_defense.py
+++ b/src/data/create_catcher_defense.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from src.utils import DBConnection, setup_logger, table_exists
+from src.config import DBConfig, LogConfig
+
+logger = setup_logger(
+    "create_catcher_defense",
+    LogConfig.LOG_DIR / "create_catcher_defense.log",
+)
+
+
+def _compute_metrics(df: pd.DataFrame) -> Dict:
+    """Compute basic framing metrics for one catcher/game."""
+    taken = ~df["description"].str.contains("swing", case=False, na=False)
+    called = df["description"].eq("called_strike")
+    called_strike_rate = called[taken].mean() if taken.any() else np.nan
+    framing_runs = called.sum()  # placeholder for more advanced metric
+    first = df.iloc[0]
+    return {
+        "game_pk": first["game_pk"],
+        "game_date": first["game_date"],
+        "catcher_id": first["fielder_2"],
+        "called_strike_rate": called_strike_rate,
+        "framing_runs": framing_runs,
+    }
+
+
+def build_catcher_defense_metrics(
+    db_path: Path = DBConfig.PATH,
+    source_table: str = "statcast_pitchers",
+    target_table: str = "catcher_defense_metrics",
+    rebuild: bool = False,
+) -> pd.DataFrame:
+    """Aggregate pitch-level data into per game catcher framing metrics."""
+    with DBConnection(db_path) as conn:
+        df = pd.read_sql_query(
+            f"SELECT game_pk, game_date, fielder_2, description FROM {source_table}",
+            conn,
+        )
+    if df.empty:
+        logger.warning("No data found in %s", source_table)
+        return df
+
+    df = df.dropna(subset=["fielder_2"])
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    rows: List[Dict] = []
+    for _, g in df.groupby(["game_pk", "fielder_2", "game_date"], sort=False):
+        rows.append(_compute_metrics(g))
+    result = pd.DataFrame(rows)
+
+    with DBConnection(db_path) as conn:
+        if rebuild or not table_exists(conn, target_table):
+            result.to_sql(target_table, conn, index=False, if_exists="replace")
+        else:
+            result.to_sql(target_table, conn, index=False, if_exists="append")
+    logger.info("Saved catcher defense metrics to %s", target_table)
+    return result
+
+
+if __name__ == "__main__":
+    try:
+        build_catcher_defense_metrics()
+    except Exception as exc:
+        logger.exception("Failed to build catcher defense metrics: %s", exc)

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -5,6 +5,7 @@ from .contextual import (
     engineer_opponent_features,
     engineer_contextual_features,
     engineer_lineup_trends,
+    engineer_catcher_defense,
 )
 from .join import build_model_features
 from .encoding import mean_target_encode
@@ -14,6 +15,7 @@ __all__ = [
     "engineer_opponent_features",
     "engineer_contextual_features",
     "engineer_lineup_trends",
+    "engineer_catcher_defense",
     "build_model_features",
     "mean_target_encode",
 ]

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -8,6 +8,7 @@ from src.features import (
     engineer_opponent_features,
     engineer_contextual_features,
     engineer_lineup_trends,
+    engineer_catcher_defense,
     build_model_features,
 )
 
@@ -50,6 +51,12 @@ def main(argv: list[str] | None = None) -> None:
         rebuild=args.rebuild,
     )
     engineer_lineup_trends(
+        db_path=args.db_path,
+        n_jobs=args.n_jobs,
+        year=args.year,
+        rebuild=args.rebuild,
+    )
+    engineer_catcher_defense(
         db_path=args.db_path,
         n_jobs=args.n_jobs,
         year=args.year,


### PR DESCRIPTION
## Summary
- include catcher_id in starting lineups
- add script to compute catcher framing metrics
- expose catcher defense rolling features
- merge catcher defense into model feature build
- update CLI and tests for new features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cb18de53c8331b10f8635ac0876eb