### PR TITLE
Add batter vs pitcher rolling history features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -142,6 +142,9 @@ class StrikeoutModelConfig:
         "offspeed_to_fastball_ratio",
         "fastball_then_breaking_rate",
         "unique_pitch_types",
+        "batter_so_rate",
+        "batter_ops",
+        "batter_whiff_rate",
     ]
     CONTEXT_ROLLING_COLS = [
         "strikeouts",

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -1,6 +1,7 @@
 """Feature engineering entry points."""
 
 from .engineer_features import engineer_pitcher_features
+from .batter_pitcher_history import engineer_batter_pitcher_history
 from .contextual import (
     engineer_opponent_features,
     engineer_contextual_features,
@@ -14,6 +15,7 @@ __all__ = [
     "engineer_opponent_features",
     "engineer_contextual_features",
     "engineer_lineup_trends",
+    "engineer_batter_pitcher_history",
     "build_model_features",
     "mean_target_encode",
 ]

--- a/src/features/batter_pitcher_history.py
+++ b/src/features/batter_pitcher_history.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+
+from src.utils import DBConnection, setup_logger, table_exists, get_latest_date
+from src.config import DBConfig, LogConfig, StrikeoutModelConfig
+from .engineer_features import add_rolling_features
+
+logger = setup_logger(
+    "batter_pitcher_history",
+    LogConfig.LOG_DIR / "batter_pitcher_history.log",
+)
+
+
+def engineer_batter_pitcher_history(
+    db_path: Path | None = None,
+    source_table: str = "game_level_batters_vs_starters",
+    date_table: str = "game_level_starting_pitchers",
+    target_table: str = "rolling_batter_pitcher_history",
+    year: int | None = None,
+    rebuild: bool = False,
+) -> pd.DataFrame:
+    """Compute rolling batter vs pitcher history metrics."""
+
+    db_path = db_path or DBConfig.PATH
+    logger.info("Loading batter vs starter data from %s", source_table)
+    with DBConnection(db_path) as conn:
+        if rebuild and table_exists(conn, target_table):
+            conn.execute(f"DROP TABLE IF EXISTS {target_table}")
+            latest = None
+        else:
+            latest = get_latest_date(conn, target_table, "game_date")
+
+        query = f"SELECT * FROM {source_table}"
+        if year:
+            query += f" WHERE strftime('%Y', game_date) = '{year}'"
+        df = pd.read_sql_query(query, conn)
+
+        if "game_date" not in df.columns:
+            date_df = pd.read_sql_query(
+                f"SELECT game_pk, game_date FROM {date_table}", conn
+            )
+            df = df.merge(date_df, on="game_pk", how="left")
+
+    if df.empty:
+        logger.warning("No data found in %s", source_table)
+        return df
+
+    df["game_date"] = pd.to_datetime(df["game_date"])
+    if latest is not None:
+        df = df[df["game_date"] > latest]
+    if df.empty:
+        logger.info("No new rows to process for %s", target_table)
+        return df
+
+    group_cols = ["pitcher_id", "batter_id", "game_date"]
+    agg_dict = {
+        "game_pk": "first",
+        "plate_appearances": "sum",
+        "strikeouts": "sum",
+        "ops": "mean",
+    }
+    if "swings" in df.columns:
+        agg_dict["swings"] = "sum"
+    if "whiffs" in df.columns:
+        agg_dict["whiffs"] = "sum"
+
+    agg = df.groupby(group_cols).agg(agg_dict).reset_index()
+
+    agg["batter_so_rate"] = agg["strikeouts"] / agg["plate_appearances"]
+    if "swings" in df.columns and "whiffs" in df.columns:
+        agg["batter_whiff_rate"] = agg["whiffs"] / agg["swings"]
+    else:
+        agg["batter_whiff_rate"] = pd.NA
+    agg["batter_ops"] = agg["ops"]
+
+    pair_key = agg["pitcher_id"].astype(str) + "_" + agg["batter_id"].astype(str)
+    agg["pair_key"] = pair_key
+
+    agg = add_rolling_features(
+        agg,
+        group_col="pair_key",
+        date_col="game_date",
+        windows=StrikeoutModelConfig.WINDOW_SIZES,
+        numeric_cols=["batter_so_rate", "batter_ops", "batter_whiff_rate"],
+        ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
+    )
+
+    agg = agg.drop(columns=["pair_key"])
+
+    with DBConnection(db_path) as conn:
+        if rebuild or not table_exists(conn, target_table):
+            agg.to_sql(target_table, conn, if_exists="replace", index=False)
+        else:
+            agg.to_sql(target_table, conn, if_exists="append", index=False)
+    logger.info("Saved batter-pitcher history to %s", target_table)
+    return agg
+
+
+if __name__ == "__main__":
+    engineer_batter_pitcher_history()

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -8,6 +8,7 @@ from src.features import (
     engineer_opponent_features,
     engineer_contextual_features,
     engineer_lineup_trends,
+    engineer_batter_pitcher_history,
     build_model_features,
 )
 
@@ -46,6 +47,11 @@ def main(argv: list[str] | None = None) -> None:
     engineer_contextual_features(
         db_path=args.db_path,
         n_jobs=args.n_jobs,
+        year=args.year,
+        rebuild=args.rebuild,
+    )
+    engineer_batter_pitcher_history(
+        db_path=args.db_path,
         year=args.year,
         rebuild=args.rebuild,
     )

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -9,6 +9,7 @@ from src.features import (
     engineer_opponent_features,
     engineer_contextual_features,
     engineer_lineup_trends,
+    engineer_batter_pitcher_history,
     build_model_features,
 )
 from src.features.engineer_features import add_rolling_features
@@ -68,11 +69,14 @@ def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
             {
                 "game_pk": [1, 2, 3],
                 "pitcher_id": [10, 10, 10],
+                "batter_id": ["101", "102", "103"],
                 "opponent_team": ["A", "B", "C"],
                 "stand": ["R", "L", "L"],
                 "plate_appearances": [4, 4, 4],
                 "strikeouts": [1, 2, 1],
                 "ops": [0.7, 0.75, 0.72],
+                "swings": [10, 12, 11],
+                "whiffs": [3, 4, 3],
             }
         )
         batter_df.to_sql("game_level_batters_vs_starters", conn, index=False)
@@ -80,7 +84,8 @@ def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
         lineup_df = pd.DataFrame(
             {
                 "game_pk": [1, 2, 3],
-                "pitcher_id": [10, 10, 10],
+                "team": ["A", "B", "C"],
+                "batter_id": ["101", "102", "103"],
                 "lineup_avg_ops": [0.72, 0.73, 0.74],
             }
         )
@@ -95,6 +100,8 @@ def test_feature_pipeline(tmp_path: Path) -> None:
     engineer_opponent_features(db_path=db_path)
     engineer_contextual_features(db_path=db_path)
     engineer_lineup_trends(db_path=db_path)
+    engineer_batter_pitcher_history(db_path=db_path)
+    engineer_batter_pitcher_history(db_path=db_path)
     build_model_features(db_path=db_path)
 
     with sqlite3.connect(db_path) as conn:
@@ -139,6 +146,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert "game_date" in df.columns
         assert not any(c.endswith("_x") or c.endswith("_y") for c in df.columns)
         assert "slot1_lineup_ops_mean_3" in df.columns
+        assert "opp_batter_batter_so_rate_mean_3" in df.columns
 
 
 def test_old_window_columns_removed(tmp_path: Path) -> None:
@@ -200,6 +208,7 @@ def test_log_features_added(tmp_path: Path) -> None:
     engineer_opponent_features(db_path=db_path)
     engineer_contextual_features(db_path=db_path)
     engineer_lineup_trends(db_path=db_path)
+    engineer_batter_pitcher_history(db_path=db_path)
     build_model_features(db_path=db_path)
 
     with sqlite3.connect(db_path) as conn:
@@ -227,6 +236,7 @@ def test_base_context_fields_kept(tmp_path: Path) -> None:
     engineer_opponent_features(db_path=db_path)
     engineer_contextual_features(db_path=db_path)
     engineer_lineup_trends(db_path=db_path)
+    engineer_batter_pitcher_history(db_path=db_path)
     build_model_features(db_path=db_path)
 
     with sqlite3.connect(db_path) as conn:
@@ -305,6 +315,7 @@ def test_extra_cat_cols_excluded(tmp_path: Path) -> None:
         df.to_sql("contextual_features", conn, if_exists="replace", index=False)
 
     engineer_lineup_trends(db_path=db_path)
+    engineer_batter_pitcher_history(db_path=db_path)
     build_model_features(db_path=db_path)
 
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Summary
- engineer batter vs pitcher rolling stats
- merge batter-pitcher history in feature join step
- expose new feature in feature engineering script
- expand rolling column config
- update tests for new table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cb18b379883318fd0bc111975ff73