### PR TITLE
Fix pitch count rolling sum bug

### DIFF
--- a/src/features/workload_features.py
+++ b/src/features/workload_features.py
@@ -17,7 +17,9 @@ def add_recent_pitch_counts(df: pd.DataFrame, window_days: int = 7) -> pd.Series
     for pid, g in df.groupby("pitcher_id"):
         shifted = g.set_index("game_date")["pitches"].shift(1)
         rolled = shifted.rolling(f"{window_days}D").sum()
-        result_parts.append(rolled.rename(g.index))
+        # Maintain alignment with the original group by restoring its index
+        rolled.index = g.index
+        result_parts.append(rolled)
     out = pd.concat(result_parts).sort_index()
     out.name = f"pitches_last_{window_days}d"
     return out


### PR DESCRIPTION
## Summary
- restore group index after rolling sums in `add_recent_pitch_counts`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cb40252b48331b608bd7a27454b37