### PR TITLE
Fix catcher defense pipeline import

### DIFF
--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "engineer_contextual_features",
     "engineer_lineup_trends",
     "engineer_batter_pitcher_history",
+    "engineer_catcher_defense",
     "build_model_features",
     "mean_target_encode",
 ]

--- a/src/features/join.py
+++ b/src/features/join.py
@@ -42,6 +42,7 @@ def build_model_features(
     opp_table: str = "rolling_pitcher_vs_team",
     context_table: str = "contextual_features",
     lineup_table: str = "lineup_trends",
+    catcher_table: str = "rolling_catcher_defense",
     batter_history_table: str = "rolling_batter_pitcher_history",
     lineup_ids_table: str = "game_starting_lineups",
 
@@ -83,6 +84,9 @@ def build_model_features(
         lineup_df = pd.read_sql_query(
             base_query.format(lineup_table) + filter_clause, conn
         )
+        catcher_df = pd.read_sql_query(
+            base_query.format(catcher_table) + filter_clause, conn
+        )
         bp_df = pd.read_sql_query(
             base_query.format(batter_history_table) + filter_clause, conn
         )
@@ -94,7 +98,7 @@ def build_model_features(
         # and ``pitcher_id``. Drop duplicate instances from the right-hand
         # DataFrames before merging to avoid pandas adding suffixes that can clash
         # on subsequent merges.
-        for frame in (opp_df, ctx_df, lineup_df, bp_df, lineup_ids):
+        for frame in (opp_df, ctx_df, lineup_df, catcher_df, bp_df, lineup_ids):
 
             if "game_date" in frame.columns:
                 frame.drop(columns=["game_date"], inplace=True)

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -8,6 +8,7 @@ from src.features import (
     engineer_opponent_features,
     engineer_contextual_features,
     engineer_lineup_trends,
+    engineer_catcher_defense,
     engineer_batter_pitcher_history,
     build_model_features,
 )


### PR DESCRIPTION
## Summary
- import missing `engineer_catcher_defense` in run_feature_engineering
- load catcher defense table in `build_model_features`
- expose `engineer_catcher_defense` from `src.features`

## Testing
- `python -m py_compile src/scripts/run_feature_engineering.py src/features/join.py src/features/__init__.py`
- `pytest tests/test_feature_engineering.py::test_run_feature_engineering_script -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cb725cc4c8331aeaa50ad1259a2b8