### PR TITLE
Fix catcher defense date merge

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -558,9 +558,15 @@ def engineer_catcher_defense(
         return pd.DataFrame()
 
     metrics_df["game_date"] = pd.to_datetime(metrics_df["game_date"])
+    lineup_df["game_date"] = pd.to_datetime(lineup_df["game_date"])
     df = lineup_df.merge(
-        metrics_df, on=["game_pk", "catcher_id"], how="left"
+        metrics_df,
+        on=["game_pk", "catcher_id"],
+        how="left",
+        suffixes=("", "_metrics"),
     )
+    if "game_date_metrics" in df.columns:
+        df["game_date"] = df["game_date"].fillna(df.pop("game_date_metrics"))
     if latest is not None:
         df = df[df["game_date"] > latest]
     if df.empty:


### PR DESCRIPTION
## Summary
- ensure `game_date` persists after merging lineup and catcher metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cbf4bfca08331b7845fbaaf09d739