### PR TITLE
Fix duplicate columns in merges

### DIFF
--- a/src/create_pitcher_vs_team_stats.py
+++ b/src/create_pitcher_vs_team_stats.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pathlib import Path
 import logging
 
-from src.utils import DBConnection, setup_logger
+from src.utils import DBConnection, setup_logger, safe_merge
 from src.config import DBConfig, LogConfig
 
 STARTERS_TABLE = "game_level_starting_pitchers"
@@ -33,7 +33,7 @@ def build_matchup_stats(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
         if not set(merge_cols).issubset(team_bat.columns):
             merge_cols = ["game_pk", "pitching_team", "opponent_team"]
 
-        merged = starters.merge(team_bat, on=merge_cols, how="left")
+        merged = safe_merge(starters, team_bat, on=merge_cols, how="left")
         merged.to_sql(OUTPUT_TABLE, conn, if_exists="replace", index=False)
         logger.info("Wrote %d rows to %s", len(merged), OUTPUT_TABLE)
         return merged

--- a/src/data/create_matchup_details_table.py
+++ b/src/data/create_matchup_details_table.py
@@ -4,7 +4,7 @@ import pandas as pd
 from pathlib import Path
 import logging
 
-from src.utils import DBConnection, setup_logger
+from src.utils import DBConnection, setup_logger, safe_merge
 from src.config import DBConfig, LogConfig
 
 STARTERS_TABLE = "game_level_starting_pitchers"
@@ -38,11 +38,12 @@ def build_matchup_table(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
         cols_in_team = set(team_bat.columns)
         if not set(merge_cols).issubset(cols_in_team):
             merge_cols = ["game_pk", "pitching_team", "opponent_team"]
-        merged = starters.merge(team_bat, on=merge_cols, how="left")
+        merged = safe_merge(starters, team_bat, on=merge_cols, how="left")
 
         # Add boxscore information (joined on game_pk) and preserve existing
         # columns (including game_date) without automatic suffixing.
-        merged = merged.merge(
+        merged = safe_merge(
+            merged,
             boxscores,
             on="game_pk",
             how="left",

--- a/src/data/create_team_batting.py
+++ b/src/data/create_team_batting.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 
-from src.utils import DBConnection, setup_logger
+from src.utils import DBConnection, setup_logger, safe_merge
 from src.config import DBConfig, LogConfig
 
 logger = setup_logger(
@@ -130,7 +130,7 @@ def aggregate_team_batting(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
         team_df = pd.DataFrame()
     else:
         team_df = aggregate_from_batters(batter_df)
-        team_df = team_df.merge(starter_df, on="game_pk", how="left")
+        team_df = safe_merge(team_df, starter_df, on="game_pk", how="left")
         team_df["bat_ops_vs_LHP"] = np.where(
             team_df["pitcher_hand"] == "L", team_df["bat_ops"], np.nan
         )

--- a/src/features/batter_pitcher_history.py
+++ b/src/features/batter_pitcher_history.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pandas as pd
 from pathlib import Path
 
-from src.utils import DBConnection, setup_logger, table_exists, get_latest_date
+from src.utils import (
+    DBConnection,
+    setup_logger,
+    table_exists,
+    get_latest_date,
+    safe_merge,
+)
 from src.config import DBConfig, LogConfig, StrikeoutModelConfig
 from .engineer_features import add_rolling_features
 
@@ -41,7 +47,7 @@ def engineer_batter_pitcher_history(
             date_df = pd.read_sql_query(
                 f"SELECT game_pk, game_date FROM {date_table}", conn
             )
-            df = df.merge(date_df, on="game_pk", how="left")
+            df = safe_merge(df, date_df, on="game_pk", how="left")
 
     if df.empty:
         logger.warning("No data found in %s", source_table)


### PR DESCRIPTION
## Summary
- implement `safe_merge` and `deduplicate_columns` utilities
- use `safe_merge` across feature engineering scripts and data prep

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683cc21b38ac8331a5237e81dcb5adc3