### PR TITLE
Fix duplicate zone_pct feature

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -140,7 +140,6 @@ class StrikeoutModelConfig:
         "avg_release_speed",
         "max_release_speed",
         "avg_spin_rate",
-        "zone_pct",
         "hard_hit_rate",
         "offspeed_to_fastball_ratio",
         "fastball_then_breaking_rate",

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -88,6 +88,10 @@ def add_rolling_features(
             if c in df.columns and c not in {"game_pk", group_col}
         ]
 
+    # remove any duplicate columns while preserving order
+    seen = set()
+    numeric_cols = [c for c in numeric_cols if not (c in seen or seen.add(c))]
+
     frames = [df]
     for col in numeric_cols:
         grouped = df.groupby(group_col)[col]


### PR DESCRIPTION
## Summary
- fix duplicates in `PITCHER_ROLLING_COLS`
- guard against duplicate columns in `add_rolling_features`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d3694b76c8331b5234a9336e3f571