### PR TITLE
Fix missing barrel column in pitcher table

### DIFF
--- a/src/data/create_starting_pitcher_table.py
+++ b/src/data/create_starting_pitcher_table.py
@@ -54,7 +54,6 @@ PITCHER_COLS = [
     "release_extension",
     "launch_speed",
     "launch_angle",
-    "barrel",
     "inning",
     "type",
     "strikes",
@@ -181,9 +180,16 @@ def compute_features(df: pd.DataFrame) -> Dict:
         if "launch_speed" in bip.columns and len(bip)
         else np.nan
     )
-    barrel_rate = (
-        bip["barrel"].mean() if "barrel" in bip.columns and len(bip) else np.nan
-    )
+    if "barrel" in bip.columns and len(bip):
+        barrel_rate = bip["barrel"].mean()
+    elif {"launch_speed", "launch_angle"}.issubset(bip.columns) and len(bip):
+        is_barrel = (
+            (bip["launch_angle"].between(26, 30))
+            & (bip["launch_speed"] >= 98)
+        )
+        barrel_rate = is_barrel.mean()
+    else:
+        barrel_rate = np.nan
 
     types = df["pitch_type"].values
     next_types = np.roll(types, -1)


### PR DESCRIPTION
## Summary
- avoid selecting nonexistent `barrel` column
- derive barrel rate from launch metrics when needed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d418bcc508331b0016aa571fa7b03