### PR TITLE
Fix missing batter column in pitcher aggregation

### DIFF
--- a/src/data/create_starting_pitcher_table.py
+++ b/src/data/create_starting_pitcher_table.py
@@ -35,6 +35,7 @@ PITCHER_COLS = [
     "game_pk",
     "game_date",
     "pitcher",
+    "batter",
     "p_throws",
     "home_team",
     "away_team",


### PR DESCRIPTION
## Summary
- ensure create_starting_pitcher_table pulls the `batter` column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683d43d732d883318d5fef52e9ea55f7