### PR TITLE
Fix row duplication in feature joins

### DIFF
--- a/src/features/join.py
+++ b/src/features/join.py
@@ -113,9 +113,13 @@ def build_model_features(
             return pitcher_df
 
         df = safe_merge(pitcher_df, opp_df, on=["game_pk", "pitcher_id"], how="left")
+        df = df.drop_duplicates(subset=["game_pk", "pitcher_id"])
         df = safe_merge(df, ctx_df, on=["game_pk", "pitcher_id"], how="left")
+        df = df.drop_duplicates(subset=["game_pk", "pitcher_id"])
         df = safe_merge(df, lineup_df, on=["game_pk", "pitcher_id"], how="left")
+        df = df.drop_duplicates(subset=["game_pk", "pitcher_id"])
         df = safe_merge(df, catcher_df, on=["game_pk", "pitcher_id"], how="left")
+        df = df.drop_duplicates(subset=["game_pk", "pitcher_id"])
 
         if not bp_df.empty and not lineup_ids.empty:
             if "team" in lineup_ids.columns and "opponent_team" not in lineup_ids.columns:


### PR DESCRIPTION
## Summary
- avoid exploding row counts when merging feature tables by dropping duplicates after each merge

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e194797e48331ab87e97d8c19b1c2