### PR TITLE
Add logging for model feature column count

### DIFF
--- a/src/features/join.py
+++ b/src/features/join.py
@@ -238,6 +238,12 @@ def build_model_features(
             logger.info("No new rows to process for %s", target_table)
             return df
 
+        logger.info(
+            "Attempting to write %d columns to %s",
+            len(df.columns),
+            target_table,
+        )
+
         if rebuild or not table_exists(conn, target_table):
             df.to_sql(target_table, conn, if_exists="replace", index=False)
         else:


### PR DESCRIPTION
## Summary
- log how many columns will be written when saving model features

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e205106948331adcb3a7fe598102b