### PR TITLE
Add pitcher age and lineup K% features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -147,7 +147,6 @@ class StrikeoutModelConfig:
         "batter_so_rate",
         "batter_ops",
         "batter_whiff_rate",
-
     ]
     CONTEXT_ROLLING_COLS = [
         "strikeouts",
@@ -178,8 +177,10 @@ class StrikeoutModelConfig:
         "elevation",
         "rest_days",
         "pitches_last_7d",
+        "season_ip_last_30d",
         "on_il",
         "days_since_il",
+        "pitcher_age",
         "humidity",
         "park_factor",
         "team_k_rate",


### PR DESCRIPTION
## Summary
- compute pitcher_age from players table
- add season_ip_last_30d rolling metric
- calculate projected_lineup_k_pct
- include new columns in model features and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e4a4ea96883319b15b07899ef7771