### PR TITLE
Add feature group mapping and integrate into model importance

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -282,6 +282,7 @@ class FileConfig:
     PLOTS_DIR = PROJECT_ROOT / "plots"
     DATA_DIR = PROJECT_ROOT / "data"
     FEATURE_IMPORTANCE_FILE = MODELS_DIR / "feature_importance.csv"
+    SHAP_IMPORTANCE_FILE = MODELS_DIR / "shap_feature_importance.csv"
     # Ensure these directories exist
     MODELS_DIR.mkdir(parents=True, exist_ok=True)
     PLOTS_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/features/__init__.py
+++ b/src/features/__init__.py
@@ -11,6 +11,7 @@ from .contextual import (
 )
 from .join import build_model_features
 from .encoding import mean_target_encode
+from .feature_groups import assign_feature_group
 
 __all__ = [
     "engineer_pitcher_features",
@@ -22,4 +23,5 @@ __all__ = [
     "engineer_catcher_defense",
     "build_model_features",
     "mean_target_encode",
+    "assign_feature_group",
 ]

--- a/src/features/feature_groups.py
+++ b/src/features/feature_groups.py
@@ -1,0 +1,73 @@
+"""Utilities for grouping related feature names."""
+
+from __future__ import annotations
+
+PREFIX_TO_GROUP = {
+    # Opponent related metrics
+    "opp_": "Opponent",
+    "team_": "Opponent",
+    "team_hand_": "Opponent",
+    "lineup_": "Opponent",
+    "slot": "Opponent",
+    "opp_batter_": "Opponent",
+    "opp_lineup_": "Opponent",
+    "batter_": "Opponent",
+    # Context and environmental factors
+    "wx_": "Context",
+    "venue_": "Context",
+    "ump_": "Context",
+    "catcher_": "Context",
+    "temp": "Context",
+    "wind_speed": "Context",
+    "humidity": "Context",
+    "elevation": "Context",
+    "park_factor": "Context",
+    "day_of_week": "Context",
+    "travel_distance": "Context",
+    "pitches_last_": "Context",
+    "rest_days": "Context",
+    "on_il": "Context",
+    "days_since_il": "Context",
+    # Pitch quality and pitch mix
+    "fastball_": "Pitch_Quality",
+    "slider_": "Pitch_Quality",
+    "curve_": "Pitch_Quality",
+    "changeup_": "Pitch_Quality",
+    "cutter_": "Pitch_Quality",
+    "sinker_": "Pitch_Quality",
+    "splitter_": "Pitch_Quality",
+    "pfx_": "Pitch_Quality",
+    "release_": "Pitch_Quality",
+    "plate_": "Pitch_Quality",
+    "spin": "Pitch_Quality",
+    "whiff": "Pitch_Quality",
+    "csw": "Pitch_Quality",
+    "zone_": "Pitch_Quality",
+    "chase_": "Pitch_Quality",
+    "fastball_then_": "Pitch_Quality",
+    "offspeed_to_": "Pitch_Quality",
+    "unique_pitch_types": "Pitch_Quality",
+}
+
+# Some columns do not share common prefixes but should still be categorized
+SPECIFIC_GROUPS = {
+    "pitches_last_7d": "Context",
+    "rest_days": "Context",
+    "on_il": "Context",
+    "days_since_il": "Context",
+    "day_of_week": "Context",
+    "travel_distance": "Context",
+}
+
+DEFAULT_GROUP = "Performance"
+
+
+def assign_feature_group(feature: str) -> str:
+    """Return the feature group for ``feature`` based on prefix rules."""
+    if feature in SPECIFIC_GROUPS:
+        return SPECIFIC_GROUPS[feature]
+    for prefix, group in PREFIX_TO_GROUP.items():
+        if feature.startswith(prefix):
+            return group
+    return DEFAULT_GROUP
+

--- a/tests/test_train_models.py
+++ b/tests/test_train_models.py
@@ -29,7 +29,7 @@ def test_train_lgbm_runs(monkeypatch):
     train_df, test_df = _make_train_test_dfs()
     monkeypatch.setattr(StrikeoutModelConfig, "FINAL_ESTIMATORS", 10)
     monkeypatch.setattr(StrikeoutModelConfig, "EARLY_STOPPING_ROUNDS", 2)
-    model, metrics = train_lgbm(train_df, test_df)
+    model, metrics, features = train_lgbm(train_df, test_df)
     assert hasattr(model, "predict")
     assert set(metrics) == {"rmse", "mae", "within_1_so"}
 


### PR DESCRIPTION
## Summary
- organize feature prefixes into groups for analysis
- expose `assign_feature_group` in features package
- include new group column when computing LightGBM or SHAP feature importance
- store SHAP importance alongside gain importance
- adjust train model functions and tests accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683e4a5438448331a688856d2196ab80