### PR TITLE
Integrate SHAP-based feature pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ python -m src.scripts.shap_sweep --db-path path/to/pitcher_stats.db
 ```
 
 This writes `plots/shap_importance.csv` with the mean absolute SHAP value for each feature.
+After running the sweep, subsequent training will automatically drop columns
+with zero SHAP importance using the saved CSV.
 * Add model monitoring & alerting for production use
 
 ## How to Contribute

--- a/src/scripts/train_baseline_model.py
+++ b/src/scripts/train_baseline_model.py
@@ -15,7 +15,7 @@ from src.train_model import (
     get_gain_importance,
     get_shap_importance,
 )
-from src.features.selection import select_features
+from src.features.selection import select_features, filter_features_by_shap
 from src.utils import setup_logger
 
 
@@ -66,6 +66,7 @@ def main(argv: list[str] | None = None) -> None:
             importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
             importance_method="lightgbm",
         )
+        features = filter_features_by_shap(features)
         X_hold = holdout_df[features]
         y_hold = holdout_df[StrikeoutModelConfig.TARGET_VARIABLE]
         preds_hold = model.predict(X_hold)

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -16,7 +16,7 @@ from src.config import (
     LogConfig,
 )
 from src.utils import DBConnection, setup_logger
-from src.features.selection import select_features
+from src.features.selection import select_features, filter_features_by_shap
 from src.features.feature_groups import assign_feature_group
 
 logger = setup_logger("train_model", LogConfig.LOG_DIR / "train_model.log")
@@ -75,6 +75,7 @@ def train_lgbm(
         importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
         importance_method="lightgbm",
     )
+    features = filter_features_by_shap(features)
     logger.info("Using %d features", len(features))
     X_train = train_df[features]
     y_train = train_df[target]
@@ -127,6 +128,7 @@ def cross_validate_lgbm(
         importance_threshold=StrikeoutModelConfig.IMPORTANCE_THRESHOLD,
         importance_method="lightgbm",
     )
+    features = filter_features_by_shap(features)
     logger.info("Using %d features", len(features))
 
     X = df.sort_values("game_date")[features]

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,6 +1,10 @@
 import pandas as pd
 
-from src.features.selection import _prune_feature_importance, select_features
+from src.features.selection import (
+    _prune_feature_importance,
+    select_features,
+    filter_features_by_shap,
+)
 
 
 def test_prune_feature_importance() -> None:
@@ -55,3 +59,17 @@ def test_select_features_includes_base_numeric() -> None:
     )
     features, _ = select_features(df, "strikeouts")
     assert set(features) == {"pitches", "pitches_mean_3"}
+
+
+def test_filter_features_by_shap(tmp_path) -> None:
+    shap_path = tmp_path / "shap_importance.csv"
+    pd.DataFrame({"feature": ["a", "b"], "importance": [0.1, 0.0]}).to_csv(shap_path, index=False)
+    features = ["a", "b", "c"]
+    filtered = filter_features_by_shap(features, shap_path=shap_path)
+    assert filtered == ["a"]
+
+
+def test_filter_features_by_shap_missing(tmp_path) -> None:
+    features = ["a", "b"]
+    filtered = filter_features_by_shap(features, shap_path=tmp_path / "missing.csv")
+    assert filtered == features


### PR DESCRIPTION
## Summary
- filter features using SHAP results
- use SHAP filter in training pipeline and baseline script
- document SHAP pruning in README
- test SHAP filtering helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eaff83fbc8331b5fc6c6b23ea5355