### PR TITLE
Filter zero SHAP importances

### DIFF
--- a/src/scripts/shap_sweep.py
+++ b/src/scripts/shap_sweep.py
@@ -46,6 +46,7 @@ def main(argv: list[str] | None = None) -> None:
         values = values[0]
     importance = np.abs(values).mean(axis=0)
     shap_df = pd.DataFrame({"feature": X_train.columns, "importance": importance})
+    shap_df = shap_df[shap_df["importance"] > 0]
     shap_df.sort_values("importance", ascending=False, inplace=True)
 
     out_path = FileConfig.PLOTS_DIR / "shap_importance.csv"

--- a/src/train_model.py
+++ b/src/train_model.py
@@ -189,6 +189,7 @@ def get_shap_importance(model: LGBMRegressor, X: pd.DataFrame) -> pd.DataFrame:
         values = values[0]
     importance = np.abs(values).mean(axis=0)
     fi = pd.DataFrame({"feature": X.columns, "importance": importance})
+    fi = fi[fi["importance"] > 0].copy()
     fi["group"] = fi["feature"].map(assign_feature_group)
     fi.sort_values("importance", ascending=False, inplace=True)
     return fi


### PR DESCRIPTION
## Summary
- ignore features with zero SHAP value when saving feature importance
- prune zero-importance features in the SHAP sweep utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: network not available)*

------
https://chatgpt.com/codex/tasks/task_e_683eb6f63228833187dea1027984c0ad