### PR TITLE
Add release height feature

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -140,6 +140,7 @@ class StrikeoutModelConfig:
         "avg_release_speed",
         "max_release_speed",
         "avg_spin_rate",
+        "release_height",
         "hard_hit_rate",
         "offspeed_to_fastball_ratio",
         "fastball_then_breaking_rate",

--- a/src/data/create_starting_pitcher_table.py
+++ b/src/data/create_starting_pitcher_table.py
@@ -53,6 +53,7 @@ PITCHER_COLS = [
     "pfx_x",
     "pfx_z",
     "release_extension",
+    "release_pos_z",
     "launch_speed",
     "launch_angle",
     "inning",
@@ -234,6 +235,9 @@ def compute_features(df: pd.DataFrame) -> Dict:
         "pfx_z": df["pfx_z"].mean() if "pfx_z" in df.columns else np.nan,
         "release_extension": df["release_extension"].mean()
         if "release_extension" in df.columns
+        else np.nan,
+        "release_height": df["release_pos_z"].mean()
+        if "release_pos_z" in df.columns
         else np.nan,
         "plate_x": df["plate_x"].mean() if "plate_x" in df.columns else np.nan,
         "plate_z": df["plate_z"].mean() if "plate_z" in df.columns else np.nan,

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -57,6 +57,7 @@ def setup_test_db(tmp_path: Path, cross_season: bool = False) -> Path:
                 "pfx_x": [0.1, 0.2, 0.15],
                 "pfx_z": [-0.5, -0.6, -0.4],
                 "release_extension": [6.0, 6.1, 6.2],
+                "release_height": [6.5, 6.6, 6.7],
                 "plate_x": [-0.2, -0.3, -0.1],
                 "plate_z": [2.5, 2.6, 2.7],
             }
@@ -145,6 +146,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert "zone_pct_mean_3" in df.columns
         assert "hard_hit_rate_mean_3" in df.columns
         assert "pfx_x_mean_3" in df.columns
+        assert "release_height_mean_3" in df.columns
         assert "lineup_avg_ops_mean_3" in df.columns
         assert "team_k_rate_mean_3" in df.columns
         assert "opp_lineup_woba_mean_3" in df.columns


### PR DESCRIPTION
## Summary
- compute average release height when aggregating pitcher games
- expose release height via config rolling columns
- include release height in feature engineering tests

## Testing
- `pytest tests/test_feature_engineering.py::test_feature_pipeline -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8de6ce883318b7cb95f7b72ea65