### PR TITLE
Add season timing features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -186,6 +186,7 @@ class StrikeoutModelConfig:
         "team_k_rate",
         "day_of_week",
         "travel_distance",
+        "days_into_season",
     ]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -166,6 +166,21 @@ def engineer_pitcher_features(
         logger.info("No new rows to process for %s", target_table)
         return df
 
+    # Days into season relative to each year's first game
+    df["season_year"] = df["game_date"].dt.year
+    opening_day = df.groupby("season_year")["game_date"].transform("min")
+    df["days_into_season"] = (df["game_date"] - opening_day).dt.days
+    df.drop(columns=["season_year"], inplace=True)
+
+    month = df["game_date"].dt.month
+    df["month_bucket"] = pd.cut(
+        month,
+        bins=[0, 4, 8, 12],
+        labels=["early", "mid", "late"],
+        include_lowest=True,
+    ).astype(str)
+
+
     df["rest_days"] = calculate_rest_days(df, "pitcher_id", "game_date")
 
     # Add workload features

--- a/src/features/feature_groups.py
+++ b/src/features/feature_groups.py
@@ -57,6 +57,8 @@ SPECIFIC_GROUPS = {
     "days_since_il": "Context",
     "day_of_week": "Context",
     "travel_distance": "Context",
+    "days_into_season": "Context",
+    "month_bucket": "Context",
 }
 
 DEFAULT_GROUP = "Performance"

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -166,8 +166,11 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         # encoded categorical columns should be numeric
         assert "home_team_enc" in df.columns
         assert pd.api.types.is_numeric_dtype(df["home_team_enc"])
+        assert "month_bucket_enc" in df.columns
+        assert pd.api.types.is_numeric_dtype(df["month_bucket_enc"])
         assert "day_of_week" in df.columns
         assert "travel_distance" in df.columns
+        assert "days_into_season" in df.columns
         assert "on_il" in df.columns
         assert "days_since_il" in df.columns
         assert "pitches_last_7d" in df.columns
@@ -278,6 +281,8 @@ def test_base_context_fields_kept(tmp_path: Path) -> None:
         assert "log_park_factor" in df.columns
         assert "day_of_week" in df.columns
         assert "travel_distance" in df.columns
+        assert "days_into_season" in df.columns
+        assert "month_bucket_enc" in df.columns
 
 
 def test_rest_days_across_seasons(tmp_path: Path) -> None:
@@ -293,6 +298,9 @@ def test_rest_days_across_seasons(tmp_path: Path) -> None:
         # Cross-season gap should be calculated correctly
         assert df.loc[1, "rest_days"] == 186
         assert df.loc[2, "rest_days"] == 7
+        assert df.loc[0, "days_into_season"] == 0
+        # Next season should reset
+        assert df.loc[1, "days_into_season"] == 0
 
 
 def test_engineer_lineup_trends(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- compute days_into_season from opening day and bucket months
- allow new numeric field in config
- group new features in feature_groups
- verify with updated tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8dd85408331a893f9c4459f2951