### PR TITLE
Add pitcher pitch-decay metric

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -114,6 +114,7 @@ class StrikeoutModelConfig:
     PITCHER_ROLLING_COLS = [
         "strikeouts",
         "pitches",
+        "pitches_per_inning_decay",
         "fip",
         "csw_pct",
         "swinging_strike_rate",

--- a/src/data/create_starting_pitcher_table.py
+++ b/src/data/create_starting_pitcher_table.py
@@ -119,6 +119,11 @@ def compute_features(df: pd.DataFrame) -> Dict:
         opp = first_row["home_team"]
 
     pitches = len(df)
+    inning_counts = df.groupby("inning").size().sort_index()
+    if len(inning_counts) > 1:
+        slope = np.polyfit(inning_counts.index.values, inning_counts.values, 1)[0]
+    else:
+        slope = np.nan
     strike_events = df["events"].isin(["strikeout", "strikeout_double_play"])
     swinging = df["description"].str.contains("swinging_strike", na=False)
     called = df["description"].eq("called_strike")
@@ -203,6 +208,7 @@ def compute_features(df: pd.DataFrame) -> Dict:
         "pitching_team": team,
         "opponent_team": opp,
         "pitches": pitches,
+        "pitches_per_inning_decay": slope,
         "innings_pitched": df["inning"].nunique(),
         "batters_faced": df["batter"].nunique(),
         "strikeouts": strike_events.sum(),


### PR DESCRIPTION
## Summary
- compute pitch count by inning and fit regression to measure decay
- store `pitches_per_inning_decay` on the game-level table
- include the new metric in rolling pitcher features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8dc9e508331b462816b3cea122c