### PR TITLE
Add season IP last 14 days feature

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -177,6 +177,7 @@ class StrikeoutModelConfig:
         "elevation",
         "rest_days",
         "pitches_last_7d",
+        "season_ip_last_14d",
         "season_ip_last_30d",
         "on_il",
         "days_since_il",

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -182,6 +182,7 @@ def engineer_pitcher_features(
             player_df = pd.DataFrame(columns=["player_id", "birth_date"])
 
     df["pitches_last_7d"] = add_recent_pitch_counts(df, 7)
+    df["season_ip_last_14d"] = add_recent_innings(df, 14)
     df["season_ip_last_30d"] = add_recent_innings(df, 30)
     df = add_injury_indicators(df, injury_df)
     df = add_pitcher_age(df, player_df)

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -171,6 +171,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert "on_il" in df.columns
         assert "days_since_il" in df.columns
         assert "pitches_last_7d" in df.columns
+        assert "season_ip_last_14d" in df.columns
         assert "season_ip_last_30d" in df.columns
         assert "pitcher_age" in df.columns
         assert pd.api.types.is_numeric_dtype(df["on_il"])


### PR DESCRIPTION
## Summary
- compute recent innings pitched over last 14 days in feature engineering
- expose the new column in the config's allowed base numeric columns
- test for the new `season_ip_last_14d` feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8dafc9c8331a6206d87311d2ad3