### PR TITLE
Add batters faced rolling stat

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -123,6 +123,7 @@ class StrikeoutModelConfig:
         "two_strike_k_rate",
         "high_leverage_k_rate",
         "woba_runners_on",
+        "batters_faced",
         "slider_pct",
         "curve_pct",
         "changeup_pct",

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -141,6 +141,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert "two_strike_k_rate_mean_3" in df.columns
         assert "high_leverage_k_rate_mean_3" in df.columns
         assert "woba_runners_on_mean_3" in df.columns
+        assert "batters_faced_mean_3" in df.columns
         assert "unique_pitch_types_mean_3" in df.columns
         assert "zone_pct_mean_3" in df.columns
         assert "hard_hit_rate_mean_3" in df.columns


### PR DESCRIPTION
## Summary
- compute rolling features for `batters_faced`
- ensure feature engineering pipeline exposes `batters_faced_mean_3`

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8dbbe688331b3c466ec701050e0