### PR TITLE
Add drop flag features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -186,6 +186,8 @@ class StrikeoutModelConfig:
         "team_k_rate",
         "day_of_week",
         "travel_distance",
+        "velocity_drop_flag",
+        "spin_drop_flag",
     ]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -19,6 +19,7 @@ from .workload_features import (
     add_injury_indicators,
     add_pitcher_age,
     add_recent_innings,
+    add_drop_flags,
 )
 
 logger = setup_logger(
@@ -195,6 +196,8 @@ def engineer_pitcher_features(
         numeric_cols=StrikeoutModelConfig.PITCHER_ROLLING_COLS,
         ewm_halflife=StrikeoutModelConfig.EWM_HALFLIFE,
     )
+
+    df = add_drop_flags(df)
 
     with DBConnection(db_path) as conn:
         if rebuild or not table_exists(conn, target_table):


### PR DESCRIPTION
## Summary
- add `velocity_drop_flag` and `spin_drop_flag`
- integrate drop flag generation in rolling pitcher features
- whitelist drop flags in configuration
- check for new flags in tests
- add unit test for drop flag logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8dc08dc8331a5a01be4afd75ffc