### PR TITLE
Add time zone tracking for ballparks

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -52,6 +52,40 @@ BALLPARK_COORDS = {
     "Nationals Park": (38.8731, -77.0074),
 }
 
+# Map stadium name to IANA time zone identifier
+BALLPARK_TIME_ZONES = {
+    "Chase Field": "America/Phoenix",
+    "Truist Park": "America/New_York",
+    "Oriole Park at Camden Yards": "America/New_York",
+    "Fenway Park": "America/New_York",
+    "Wrigley Field": "America/Chicago",
+    "Guaranteed Rate Field": "America/Chicago",
+    "Great American Ball Park": "America/New_York",
+    "Progressive Field": "America/New_York",
+    "Coors Field": "America/Denver",
+    "Comerica Park": "America/Detroit",
+    "Minute Maid Park": "America/Chicago",
+    "Kauffman Stadium": "America/Chicago",
+    "Angel Stadium": "America/Los_Angeles",
+    "Dodger Stadium": "America/Los_Angeles",
+    "loanDepot Park": "America/New_York",
+    "American Family Field": "America/Chicago",
+    "Target Field": "America/Chicago",
+    "Citi Field": "America/New_York",
+    "Yankee Stadium": "America/New_York",
+    "Oakland Coliseum": "America/Los_Angeles",
+    "Citizens Bank Park": "America/New_York",
+    "PNC Park": "America/New_York",
+    "Petco Park": "America/Los_Angeles",
+    "Oracle Park": "America/Los_Angeles",
+    "T-Mobile Park": "America/Los_Angeles",
+    "Busch Stadium": "America/Chicago",
+    "Tropicana Field": "America/New_York",
+    "Globe Life Field": "America/Chicago",
+    "Rogers Centre": "America/Toronto",
+    "Nationals Park": "America/New_York",
+}
+
 # Approximate run-scoring park factors indexed by stadium name. Values above 100
 # indicate a hitter-friendly environment while numbers below 100 favor
 # pitchers.  These are coarse averages and can be refined when more granular
@@ -186,6 +220,7 @@ class StrikeoutModelConfig:
         "team_k_rate",
         "day_of_week",
         "travel_distance",
+        "time_zone_change",
     ]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)

--- a/src/features/feature_groups.py
+++ b/src/features/feature_groups.py
@@ -24,6 +24,7 @@ PREFIX_TO_GROUP = {
     "park_factor": "Context",
     "day_of_week": "Context",
     "travel_distance": "Context",
+    "time_zone_change": "Context",
     "pitches_last_": "Context",
     "rest_days": "Context",
     "on_il": "Context",
@@ -57,6 +58,7 @@ SPECIFIC_GROUPS = {
     "days_since_il": "Context",
     "day_of_week": "Context",
     "travel_distance": "Context",
+    "time_zone_change": "Context",
 }
 
 DEFAULT_GROUP = "Performance"

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -168,6 +168,7 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert pd.api.types.is_numeric_dtype(df["home_team_enc"])
         assert "day_of_week" in df.columns
         assert "travel_distance" in df.columns
+        assert "time_zone_change" in df.columns
         assert "on_il" in df.columns
         assert "days_since_il" in df.columns
         assert "pitches_last_7d" in df.columns
@@ -278,6 +279,7 @@ def test_base_context_fields_kept(tmp_path: Path) -> None:
         assert "log_park_factor" in df.columns
         assert "day_of_week" in df.columns
         assert "travel_distance" in df.columns
+        assert "time_zone_change" in df.columns
 
 
 def test_rest_days_across_seasons(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend ballpark config with stadium time zones
- compute time zone change feature in contextual features
- categorize new feature and allow it in model
- test for new column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8e30d008331a9de310374c8602d