### PR TITLE
Add context interaction features

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -186,6 +186,8 @@ class StrikeoutModelConfig:
         "team_k_rate",
         "day_of_week",
         "travel_distance",
+        "day_of_week_x_rest_days",
+        "travel_distance_x_day_of_week",
     ]
     DEFAULT_TRAIN_YEARS = (2016, 2017, 2018, 2019, 2021, 2022, 2023)
     DEFAULT_TEST_YEARS = (2024, 2025)

--- a/src/features/join.py
+++ b/src/features/join.py
@@ -195,6 +195,14 @@ def build_model_features(
         if drop_cols:
             df = df.drop(columns=drop_cols)
 
+        # Interaction features between contextual variables
+        if {"day_of_week", "rest_days"}.issubset(df.columns):
+            df["day_of_week_x_rest_days"] = df["day_of_week"] * df["rest_days"]
+        if {"travel_distance", "day_of_week"}.issubset(df.columns):
+            df["travel_distance_x_day_of_week"] = (
+                df["travel_distance"] * df["day_of_week"]
+            )
+
         # Drop numeric columns that would leak information. Only rolling stats
         # or explicitly whitelisted numeric columns are kept.
         allowed_numeric = set(StrikeoutModelConfig.ALLOWED_BASE_NUMERIC_COLS)

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -168,6 +168,8 @@ def test_feature_pipeline(tmp_path: Path) -> None:
         assert pd.api.types.is_numeric_dtype(df["home_team_enc"])
         assert "day_of_week" in df.columns
         assert "travel_distance" in df.columns
+        assert "day_of_week_x_rest_days" in df.columns
+        assert "travel_distance_x_day_of_week" in df.columns
         assert "on_il" in df.columns
         assert "days_since_il" in df.columns
         assert "pitches_last_7d" in df.columns
@@ -278,6 +280,8 @@ def test_base_context_fields_kept(tmp_path: Path) -> None:
         assert "log_park_factor" in df.columns
         assert "day_of_week" in df.columns
         assert "travel_distance" in df.columns
+        assert "day_of_week_x_rest_days" in df.columns
+        assert "travel_distance_x_day_of_week" in df.columns
 
 
 def test_rest_days_across_seasons(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- generate interaction features when assembling model features
- keep new interaction fields
- test the new interactions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683eb8e6b12083319e039060e22a3ecf