### PR TITLE
Use boxscore data to limit daily pitcher fetch

### DIFF
--- a/src/data/mlb_api.py
+++ b/src/data/mlb_api.py
@@ -1,6 +1,6 @@
 # src/data/mlb_api.py (Updated for MLB Stats API)
 
-import httpx # Use httpx for consistency with scrape_mlb_boxscores.py
+import httpx  # Use httpx for consistency with fetch_mlb_boxscores.py
 import pandas as pd
 import json
 import logging
@@ -56,7 +56,7 @@ MLB_TRANSACTIONS_ENDPOINT = MLB_STATS_API_BASE + "/transactions"
 # Includes gamePk, status, teams(abbr, name, id, league), probablePitcher(id, fullName)
 SCHEDULE_API_FIELDS = "dates,date,games,gamePk,status,abstractGameState,teams,team,id,name,abbreviation,league,probablePitcher,id,fullName"
 
-# Use headers similar to scrape_mlb_boxscores
+# Use headers similar to fetch_mlb_boxscores
 API_HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36',
     'Accept': 'application/json',
@@ -68,7 +68,7 @@ INITIAL_RETRY_DELAY = DataConfig.INITIAL_RETRY_DELAY if hasattr(DataConfig, 'INI
 MAX_RETRY_DELAY = DataConfig.MAX_RETRY_DELAY if hasattr(DataConfig, 'MAX_RETRY_DELAY') else 10
 REQUEST_TIMEOUT = DataConfig.REQUEST_TIMEOUT if hasattr(DataConfig, 'REQUEST_TIMEOUT') else 20
 
-# --- Retry Logic (adapted from scrape_mlb_boxscores.py) ---
+# --- Retry Logic (adapted from fetch_mlb_boxscores.py) ---
 RETRY_EXCEPTIONS = (httpx.RequestError, httpx.TimeoutException, httpx.HTTPStatusError)
 def is_retryable_exception(exception):
     """Determine if an exception is retryable."""

--- a/tests/test_parse_api_data.py
+++ b/tests/test_parse_api_data.py
@@ -1,5 +1,5 @@
 import pytest
-from src.scripts.scrape_mlb_boxscores import parse_api_data, MLB_LEAGUE_IDS
+from src.scripts.fetch_mlb_boxscores import parse_api_data, MLB_LEAGUE_IDS
 
 
 def _base_sample(final=True):


### PR DESCRIPTION
## Summary
- rename scraper to `fetch_mlb_boxscores.py`
- update mlb_api comments
- provide `fetch_boxscores_for_date` helper
- use boxscore pitchers when fetching single-date data
- update unit test imports

## Testing
- `python -m py_compile src/scripts/data_fetcher.py src/scripts/fetch_mlb_boxscores.py src/data/mlb_api.py tests/test_parse_api_data.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68411c12de8483319312978c5343f614