### PR TITLE
Add switch to disable feature grouping

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -292,6 +292,9 @@ class StrikeoutModelConfig:
 
     IMPORTANCE_THRESHOLD = 0.02
 
+    # Enable grouping of related features when saving importance files
+    FEATURE_GROUPING = False
+
 
 class LogConfig:
     # Define Log directory relative to project root


### PR DESCRIPTION
## Summary
- make feature grouping optional with `StrikeoutModelConfig.FEATURE_GROUPING`
- respect the setting when saving LightGBM feature importance

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68421494ced88331aea8a31444b0b90b