### PR TITLE
Filter spring training games

### DIFF
--- a/src/scripts/modules/fetch_utils.py
+++ b/src/scripts/modules/fetch_utils.py
@@ -4,6 +4,22 @@ from __future__ import annotations
 import pandas as pd
 import logging
 
+# Known first regular-season dates per year
+REG_SEASON_START = {
+    2016: "2016-04-03",
+    2017: "2017-04-02",
+    2018: "2018-03-29",
+    2019: "2019-03-20",
+    2020: "2020-07-23",
+    2021: "2021-04-01",
+    2022: "2022-04-07",
+    2023: "2023-03-30",
+    2024: "2024-03-28",
+    2025: "2025-03-27",
+}
+DEFAULT_START_MONTH = 3
+DEFAULT_START_DAY = 25
+
 UNIQUE_PITCH_COLS = ["game_pk", "pitcher", "inning", "batter", "pitch_number"]
 
 logger = logging.getLogger(__name__)
@@ -19,12 +35,40 @@ def dedup_pitch_df(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def _season_start_date(year: int) -> pd.Timestamp:
+    start = REG_SEASON_START.get(year)
+    if start:
+        return pd.to_datetime(start)
+    return pd.Timestamp(year=year, month=DEFAULT_START_MONTH, day=DEFAULT_START_DAY)
+
+
 def filter_regular_season(df: pd.DataFrame) -> pd.DataFrame:
-    """Return only regular season rows if ``game_type`` column is present."""
+    """Return only regular season rows."""
+    if df is None or df.empty:
+        return df
+
+    df = df.copy()
+
     if "game_type" in df.columns:
         before = len(df)
         df = df[df["game_type"] == "R"]
         removed = before - len(df)
         if removed > 0:
-            logger.debug("Filtered %d non-regular season rows", removed)
+            logger.debug("Filtered %d non-regular season rows by game_type", removed)
+
+    if "game_date" in df.columns:
+        df["game_date"] = pd.to_datetime(df["game_date"], errors="coerce")
+        mask = []
+        for dt in df["game_date"]:
+            if pd.isna(dt):
+                mask.append(False)
+                continue
+            start_date = _season_start_date(dt.year)
+            mask.append(dt >= start_date)
+        before = len(df)
+        df = df[pd.Series(mask, index=df.index)]
+        removed = before - len(df)
+        if removed > 0:
+            logger.debug("Filtered %d rows prior to regular season start", removed)
+
     return df


### PR DESCRIPTION
## Summary
- drop spring training rows before each season's start date
- update fetcher tests for new date filtering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68433793fd288331845303bb55e0bdb4