### PR TITLE
Add boxscore update to data_cli

### DIFF
--- a/src/scripts/data_cli.py
+++ b/src/scripts/data_cli.py
@@ -8,8 +8,17 @@ from pathlib import Path
 from datetime import datetime
 
 from src.utils import ensure_dir, setup_logger
-from src.config import LogConfig
+from src.config import (
+    LogConfig,
+    DBConfig,
+    FileConfig,
+    MLB_BOXSCORES_TABLE,
+)
 from .data_fetcher import DataFetcher
+from .modules.store_utils import store_data_to_sql
+from . import scrape_mlb_boxscores
+import pandas as pd
+import asyncio
 
 logger = setup_logger("data_cli", log_file=Path(LogConfig.LOG_DIR) / "data_cli.log")
 
@@ -22,6 +31,43 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mlb-api", action="store_true", help="ONLY fetch probable pitchers via API for the SINGLE date specified by --date.")
     parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
     return parser.parse_args()
+
+
+def _fetch_boxscores(seasons: list[int], debug: bool = False) -> bool:
+    """Fetch MLB box scores for the given seasons and load into SQLite."""
+    if not seasons:
+        logger.warning("No seasons supplied for boxscore fetch.")
+        return True
+
+    start_date = f"{min(seasons)}-01-01"
+    end_date = f"{max(seasons)}-12-31"
+    logger.info("Fetching boxscores from %s to %s", start_date, end_date)
+    try:
+        asyncio.run(
+            scrape_mlb_boxscores.main(start_date, end_date, debug_api=debug)
+        )
+    except Exception as exc:
+        logger.error("Boxscore scraping failed: %s", exc, exc_info=True)
+        return False
+
+    csv_path = FileConfig.DATA_DIR / "raw" / "mlb_boxscores_combined.csv"
+    if not csv_path.exists():
+        logger.error("Expected CSV not found: %s", csv_path)
+        return False
+    try:
+        df = pd.read_csv(csv_path)
+    except Exception as exc:
+        logger.error("Failed reading CSV %s: %s", csv_path, exc)
+        return False
+    if df.empty:
+        logger.warning("No boxscore rows read from %s", csv_path)
+
+    return store_data_to_sql(
+        df,
+        MLB_BOXSCORES_TABLE,
+        DBConfig.PATH,
+        if_exists="replace",
+    )
 
 
 def main() -> int:
@@ -51,6 +97,15 @@ def main() -> int:
     logger.info("--- Initializing MLB Data Fetcher ---")
     fetcher = DataFetcher(args)
     success = fetcher.run()
+
+    if success and not args.mlb_api:
+        if fetcher.single_date_historical_mode:
+            seasons = [fetcher.target_fetch_date_obj.year]
+        else:
+            seasons = fetcher.seasons_to_fetch
+        bs_ok = _fetch_boxscores(seasons, debug=args.debug)
+        success = success and bs_ok
+
     if success:
         logger.info("--- Data Fetching Script Finished Successfully ---")
         return 0


### PR DESCRIPTION
## Summary
- extend `data_cli` to also fetch boxscore CSVs
- import the CSV into the `mlb_boxscores` table after other fetches

## Testing
- `python -m py_compile src/scripts/data_cli.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68461589bf30833189766ce287332ad5