### PR TITLE
Fix schedule hydration for MLB API

### DIFF
--- a/src/data/mlb_api.py
+++ b/src/data/mlb_api.py
@@ -52,9 +52,14 @@ logger = setup_logger('mlb_api_module', log_file= log_dir / 'mlb_api.log', level
 MLB_STATS_API_BASE = "https://statsapi.mlb.com/api/v1"
 MLB_SCHEDULE_ENDPOINT = MLB_STATS_API_BASE + "/schedule"
 MLB_TRANSACTIONS_ENDPOINT = MLB_STATS_API_BASE + "/transactions"
-# Define fields for the schedule endpoint to get necessary info
-# Includes gamePk, status, teams(abbr, name, id, league), probablePitcher(id, fullName)
-SCHEDULE_API_FIELDS = "dates,date,games,gamePk,status,abstractGameState,teams,team,id,name,abbreviation,league,probablePitcher,id,fullName"
+# The schedule endpoint can be limited via a ``fields`` parameter.  A previous
+# attempt to enumerate nested fields inadvertently omitted required keys,
+# resulting in empty responses.  Leaving ``fields`` unset ensures the payload
+# contains all game data, including probable pitchers.
+SCHEDULE_API_FIELDS = None
+# Explicitly request probable pitchers via ``hydrate`` to guarantee the API
+# includes this information for historical dates.
+SCHEDULE_API_HYDRATE = "probablePitcher"
 
 # Use headers similar to scrape_mlb_boxscores
 API_HEADERS = {
@@ -92,11 +97,14 @@ retry_decorator = retry(
 def fetch_schedule_api(target_date_str):
     """Fetches schedule data from MLB Stats API for a specific date with retries."""
     params = {
-        "sportId": 1, # MLB
+        "sportId": 1,  # MLB
         "startDate": target_date_str,
         "endDate": target_date_str,
-        "fields": SCHEDULE_API_FIELDS # Use the defined fields string
     }
+    if SCHEDULE_API_HYDRATE:
+        params["hydrate"] = SCHEDULE_API_HYDRATE
+    if SCHEDULE_API_FIELDS:
+        params["fields"] = SCHEDULE_API_FIELDS
     logger.debug(f"Fetching API URL: {MLB_SCHEDULE_ENDPOINT} with params: {params}")
     # Use synchronous httpx client for this non-async script part
     with httpx.Client(headers=API_HEADERS, timeout=REQUEST_TIMEOUT) as client:


### PR DESCRIPTION
## Summary
- request probable pitchers via `hydrate` parameter in MLB schedule API
- clarify docs on fields constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684746017e748331918bcabf69db5c24