### PR TITLE
Refactor rolling feature helpers

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -110,6 +110,8 @@ def _add_group_rolling(
         Prefix for the generated feature names.
     windows : list[int], optional
         Rolling window sizes. Defaults to ``StrikeoutModelConfig.WINDOW_SIZES``.
+    n_jobs : int, optional
+        Parameter preserved for backward compatibility. Currently unused.
     numeric_cols : Sequence[str], optional
         Restrict calculations to these numeric columns. If ``None`` (default),
         all numeric columns except identifiers are used.
@@ -121,9 +123,6 @@ def _add_group_rolling(
     if windows is None:
         windows = StrikeoutModelConfig.WINDOW_SIZES
 
-    if n_jobs is None:
-        n_jobs = os.cpu_count() or 1
-
     df = df.sort_values(list(group_cols) + [date_col])
     exclude_cols = {"game_pk"}.union(set(group_cols))
     if numeric_cols is None:
@@ -133,50 +132,40 @@ def _add_group_rolling(
             if c not in exclude_cols
         ]
     else:
-        numeric_cols = [
-            c for c in numeric_cols if c in df.columns and c not in exclude_cols
+        numeric_cols = [c for c in numeric_cols if c in df.columns and c not in exclude_cols]
+
+    df_idx = df.set_index(list(group_cols) + [date_col])
+    shifted = df_idx[numeric_cols].groupby(level=group_cols).shift(1)
+
+    frames = [df_idx]
+    for window in windows:
+        roll = (
+            shifted.groupby(level=group_cols, group_keys=False)[numeric_cols]
+            .rolling(window, min_periods=1)
+            .agg(["mean", "std"])
+        )
+        means = roll.xs("mean", level=-1, axis=1)
+        stds = roll.xs("std", level=-1, axis=1)
+        means.columns = [f"{prefix}{c}_mean_{window}" for c in numeric_cols]
+        stds.columns = [f"{prefix}{c}_std_{window}" for c in numeric_cols]
+        momentum = shifted[numeric_cols] - means
+        momentum.columns = [f"{prefix}{c}_momentum_{window}" for c in numeric_cols]
+        frames.extend([means, stds, momentum])
+
+    if ewm_halflife is not None:
+        ewm = (
+            shifted.groupby(level=group_cols, group_keys=False)[numeric_cols]
+            .apply(lambda x: x.ewm(halflife=ewm_halflife, min_periods=1).mean())
+        )
+        ewm.columns = [f"{prefix}{c}_ewm_{int(ewm_halflife)}" for c in numeric_cols]
+        momentum_ewm = shifted[numeric_cols] - ewm
+        momentum_ewm.columns = [
+            f"{prefix}{c}_momentum_ewm_{int(ewm_halflife)}" for c in numeric_cols
         ]
+        frames.extend([ewm, momentum_ewm])
 
-    def _calc_for_col(col: str, local_df: pd.DataFrame) -> pd.DataFrame:
-        """Calculate rolling stats for a single column using a dataframe slice."""
-        grouped = local_df.groupby(list(group_cols))[col]
-        shifted = grouped.shift(1)
-        parts = []
-        for window in windows:
-            roll = shifted.groupby([local_df[c] for c in group_cols]).rolling(
-                window, min_periods=1
-            )
-            mean = roll.mean().reset_index(
-                level=list(range(len(group_cols))), drop=True
-            )
-            stats = pd.DataFrame(
-                {
-                    f"{prefix}{col}_mean_{window}": mean,
-                    f"{prefix}{col}_std_{window}": roll.std().reset_index(
-                        level=list(range(len(group_cols))), drop=True
-                    ),
-                }
-            )
-            stats[f"{prefix}{col}_momentum_{window}"] = shifted - mean
-            parts.append(stats)
-        if ewm_halflife is not None:
-            ewm = grouped.apply(
-                lambda x: x.shift(1).ewm(halflife=ewm_halflife, min_periods=1).mean()
-            )
-            ewm = ewm.reset_index(level=list(range(len(group_cols))), drop=True)
-            ewm_stats = pd.DataFrame({f"{prefix}{col}_ewm_{int(ewm_halflife)}": ewm})
-            ewm_stats[f"{prefix}{col}_momentum_ewm_{int(ewm_halflife)}"] = shifted - ewm
-            parts.append(ewm_stats)
-        return pd.concat(parts, axis=1)
-
-    frames = [df]
-    results = Parallel(n_jobs=n_jobs)(
-        delayed(_calc_for_col)(c, df[[c, *group_cols, date_col]]) for c in numeric_cols
-    )
-    frames.extend(results)
-
-    df = pd.concat(frames, axis=1)
-    return df
+    result = pd.concat(frames, axis=1)
+    return result.reset_index()
 
 
 def engineer_opponent_features(

--- a/src/features/engineer_features.py
+++ b/src/features/engineer_features.py
@@ -97,33 +97,36 @@ def add_rolling_features(
     seen = set()
     numeric_cols = [c for c in numeric_cols if not (c in seen or seen.add(c))]
 
-    frames = [df]
-    for col in numeric_cols:
-        grouped = df.groupby(group_col)[col]
-        shifted = grouped.shift(1)
-        for window in windows:
-            roll = shifted.groupby(df[group_col]).rolling(window, min_periods=1)
-            mean = roll.mean().reset_index(level=0, drop=True)
-            stats = pd.DataFrame(
-                {
-                    f"{col}_mean_{window}": mean,
-                    f"{col}_std_{window}": roll.std().reset_index(level=0, drop=True),
-                }
-            )
-            # Momentum compares last game's value to the previous average
-            stats[f"{col}_momentum_{window}"] = shifted - mean
-            frames.append(stats)
-        if ewm_halflife is not None:
-            ewm = grouped.apply(
-                lambda x: x.shift(1).ewm(halflife=ewm_halflife, min_periods=1).mean()
-            )
-            ewm = ewm.reset_index(level=0, drop=True)
-            ewm_stats = pd.DataFrame({f"{col}_ewm_{int(ewm_halflife)}": ewm})
-            ewm_stats[f"{col}_momentum_ewm_{int(ewm_halflife)}"] = shifted - ewm
-            frames.append(ewm_stats)
+    df_idx = df.set_index([group_col, date_col])
+    shifted = df_idx[numeric_cols].groupby(level=0).shift(1)
 
-    df = pd.concat(frames, axis=1)
-    return df
+    frames = [df_idx]
+    for window in windows:
+        roll = (
+            shifted.groupby(level=0, group_keys=False)[numeric_cols]
+            .rolling(window, min_periods=1)
+            .agg(["mean", "std"])
+        )
+        means = roll.xs("mean", level=-1, axis=1)
+        stds = roll.xs("std", level=-1, axis=1)
+        means.columns = [f"{c}_mean_{window}" for c in numeric_cols]
+        stds.columns = [f"{c}_std_{window}" for c in numeric_cols]
+        momentum = shifted[numeric_cols] - means
+        momentum.columns = [f"{c}_momentum_{window}" for c in numeric_cols]
+        frames.extend([means, stds, momentum])
+
+    if ewm_halflife is not None:
+        ewm = (
+            shifted.groupby(level=0, group_keys=False)[numeric_cols]
+            .apply(lambda x: x.ewm(halflife=ewm_halflife, min_periods=1).mean())
+        )
+        ewm.columns = [f"{c}_ewm_{int(ewm_halflife)}" for c in numeric_cols]
+        momentum_ewm = shifted[numeric_cols] - ewm
+        momentum_ewm.columns = [f"{c}_momentum_ewm_{int(ewm_halflife)}" for c in numeric_cols]
+        frames.extend([ewm, momentum_ewm])
+
+    result = pd.concat(frames, axis=1)
+    return result.reset_index()
 
 
 def engineer_pitcher_features(


### PR DESCRIPTION
## Summary
- refactor `_add_group_rolling` to shift once with a multi-index and compute all columns together
- refactor `add_rolling_features` similarly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684927a8a1c883318cbb129f4a04bae4