### PR TITLE
Fix DB path handling in feature engineering CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ sequentially calls `engineer_pitcher_features`, `engineer_workload_features`,
 `engineer_opponent_features`, `engineer_contextual_features`,
 `engineer_lineup_trends` and then `build_model_features`. The `lineup_trends`
 table must be present for the final
-join:
+join. The `--db-path` argument is optional and defaults to `DBConfig.PATH`:
 
 ```bash
 python -m src.scripts.run_feature_engineering --db-path path/to/pitcher_stats.db

--- a/src/scripts/run_feature_engineering.py
+++ b/src/scripts/run_feature_engineering.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from src.config import DBConfig
+
 from src.features import (
     engineer_pitcher_features,
     engineer_workload_features,
@@ -17,7 +19,12 @@ from src.features import (
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run feature engineering pipeline")
-    parser.add_argument("--db-path", type=Path, default=None, help="Path to SQLite DB")
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=DBConfig.PATH,
+        help="Path to SQLite DB",
+    )
     parser.add_argument(
         "--n-jobs",
         type=int,
@@ -37,44 +44,44 @@ def main(argv: list[str] | None = None) -> None:
     )
     args = parser.parse_args(argv)
 
-    engineer_pitcher_features(
-        db_path=args.db_path, year=args.year, rebuild=args.rebuild
-    )
+    db_path = args.db_path or DBConfig.PATH
+
+    engineer_pitcher_features(db_path=db_path, year=args.year, rebuild=args.rebuild)
     engineer_workload_features(
-        db_path=args.db_path,
+        db_path=db_path,
         year=args.year,
         rebuild=args.rebuild,
     )
     engineer_opponent_features(
-        db_path=args.db_path,
+        db_path=db_path,
         n_jobs=args.n_jobs,
         year=args.year,
         rebuild=args.rebuild,
     )
     engineer_contextual_features(
-        db_path=args.db_path,
+        db_path=db_path,
         n_jobs=args.n_jobs,
         year=args.year,
         rebuild=args.rebuild,
     )
     engineer_batter_pitcher_history(
-        db_path=args.db_path,
+        db_path=db_path,
         year=args.year,
         rebuild=args.rebuild,
     )
     engineer_lineup_trends(
-        db_path=args.db_path,
+        db_path=db_path,
         n_jobs=args.n_jobs,
         year=args.year,
         rebuild=args.rebuild,
     )
     engineer_catcher_defense(
-        db_path=args.db_path,
+        db_path=db_path,
         n_jobs=args.n_jobs,
         year=args.year,
         rebuild=args.rebuild,
     )
-    build_model_features(db_path=args.db_path, year=args.year, rebuild=args.rebuild)
+    build_model_features(db_path=db_path, year=args.year, rebuild=args.rebuild)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- default `--db-path` to `DBConfig.PATH` in run_feature_engineering
- use parsed path for all feature engineering calls
- document optional --db-path argument in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851b4dab3748331b0ebf88fdb9b5e07