### PR TITLE
Fix MultiIndex concat failure

### DIFF
--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -15,6 +15,7 @@ from src.utils import (
     safe_merge,
     load_table_cached,
     deduplicate_columns,
+    deduplicate_index,
 )
 from src.config import (
     DBConfig,
@@ -144,6 +145,7 @@ def _add_group_rolling(
         numeric_cols = [c for c in numeric_cols if c in df.columns and c not in exclude_cols]
 
     df_idx = df.set_index(list(group_cols) + [date_col])
+    df_idx = deduplicate_index(df_idx)
     shifted = df_idx[numeric_cols].groupby(level=group_cols).shift(1)
 
     frames = [df_idx]
@@ -157,8 +159,14 @@ def _add_group_rolling(
         stds = roll.xs("std", level=-1, axis=1)
         means.columns = [f"{prefix}{c}_mean_{window}" for c in numeric_cols]
         stds.columns = [f"{prefix}{c}_std_{window}" for c in numeric_cols]
-        momentum = shifted[numeric_cols] - means
-        momentum.columns = [f"{prefix}{c}_momentum_{window}" for c in numeric_cols]
+        # Subtract using numpy arrays to avoid index alignment issues when
+        # duplicate level names exist in the MultiIndex
+        momentum_values = shifted[numeric_cols].to_numpy() - means.to_numpy()
+        momentum = pd.DataFrame(
+            momentum_values,
+            index=means.index,
+            columns=[f"{prefix}{c}_momentum_{window}" for c in numeric_cols],
+        )
         frames.extend([means, stds, momentum])
 
     if ewm_halflife is not None:
@@ -167,10 +175,14 @@ def _add_group_rolling(
             .apply(lambda x: x.ewm(halflife=ewm_halflife, min_periods=1).mean())
         )
         ewm.columns = [f"{prefix}{c}_ewm_{int(ewm_halflife)}" for c in numeric_cols]
-        momentum_ewm = shifted[numeric_cols] - ewm
-        momentum_ewm.columns = [
-            f"{prefix}{c}_momentum_ewm_{int(ewm_halflife)}" for c in numeric_cols
-        ]
+        momentum_ewm_values = shifted[numeric_cols].to_numpy() - ewm.to_numpy()
+        momentum_ewm = pd.DataFrame(
+            momentum_ewm_values,
+            index=ewm.index,
+            columns=[
+                f"{prefix}{c}_momentum_ewm_{int(ewm_halflife)}" for c in numeric_cols
+            ],
+        )
         frames.extend([ewm, momentum_ewm])
 
     result = pd.concat(frames, axis=1)

--- a/src/utils.py
+++ b/src/utils.py
@@ -171,6 +171,40 @@ def deduplicate_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def deduplicate_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Ensure index level names are unique.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Input DataFrame whose ``index`` may contain duplicate level names.
+
+    Returns
+    -------
+    DataFrame
+        ``df`` with duplicate index level names suffixed with ``_1`` ``_2`` etc.
+    """
+
+    idx = df.index
+    if not isinstance(idx, pd.MultiIndex):
+        return df
+
+    counts: dict[str | None, int] = {}
+    new_names = []
+    for name in idx.names:
+        if name not in counts:
+            counts[name] = 0
+            new_names.append(name)
+        else:
+            counts[name] += 1
+            suffix = counts[name]
+            new_names.append(f"{name}_{suffix}")
+
+    if new_names != list(idx.names):
+        df.index = idx.set_names(new_names)
+    return df
+
+
 def safe_merge(
     left: pd.DataFrame,
     right: pd.DataFrame,

--- a/tests/test_feature_engineering.py
+++ b/tests/test_feature_engineering.py
@@ -15,6 +15,7 @@ from src.features import (
 )
 from src.features.engineer_features import add_rolling_features
 from src.features.contextual import _add_group_rolling
+from src.utils import deduplicate_index
 from src.config import StrikeoutModelConfig
 
 
@@ -428,3 +429,12 @@ def test_group_rolling_dedup_pitcher_id() -> None:
     )
     assert "pitcher_id" in result.columns
     assert list(result.columns).count("pitcher_id") == 1
+
+
+def test_deduplicate_index_names() -> None:
+    index = pd.MultiIndex.from_arrays(
+        [[10, 20], [1, 2]], names=["pitcher_id", "pitcher_id"]
+    )
+    df = pd.DataFrame({"strikeouts": [5, 6]}, index=index)
+    df = deduplicate_index(df)
+    assert df.index.names == ["pitcher_id", "pitcher_id_1"]


### PR DESCRIPTION
## Summary
- make index level names unique with `deduplicate_index`
- apply index deduplication in `_add_group_rolling`
- cover `deduplicate_index` with unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68532039ac50833185e6af6945d84e8b