### PR TITLE
Fix MultiIndex concat failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Contains similar data to `statcast_pitchers` but from the batter's point of view
 Includes metadata for each game such as:
 
 ```
-['game_pk', 'game_date', 'away_team', 'home_team', 'game_number', 'double_header', 'away_pitcher_ids', 'home_pitcher_ids', 'hp_umpire', '1b_umpire', '2b_umpire', '3b_umpire', 'weather', 'temp', 'wind', 'elevation', 'dayNight', 'first_pitch', 'scraped_timestamp']
+['game_pk', 'game_date', 'away_team', 'home_team', 'game_number', 'double_header',
+ 'away_pitcher_ids', 'home_pitcher_ids', 'away_starting_pitcher_id',
+ 'home_starting_pitcher_id', 'hp_umpire', '1b_umpire', '2b_umpire', '3b_umpire',
+ 'weather', 'temp', 'wind', 'elevation', 'dayNight', 'first_pitch',
+ 'scraped_timestamp']
 ```
 ### `game_starting_lineups`
 
@@ -209,7 +213,8 @@ python -m src.scripts.run_feature_engineering --db-path path/to/pitcher_stats.db
 
 `build_model_features` removes columns that could leak target information. Raw
 game outcome stats (e.g. `bat_strikeouts`) and identifier fields such as
-`away_pitcher_ids`, `home_pitcher_ids`, and `scraped_timestamp` are dropped
+`away_pitcher_ids`, `home_pitcher_ids`, `away_starting_pitcher_id`,
+`home_starting_pitcher_id`, and `scraped_timestamp` are dropped
 before saving `model_features`. Only rolling statistics or whitelisted numeric
 columns like `temp`, `wind_speed`, `park_factor`, and `team_k_rate` are
 retained.

--- a/src/data/create_matchup_details_table.py
+++ b/src/data/create_matchup_details_table.py
@@ -4,7 +4,12 @@ import pandas as pd
 from pathlib import Path
 import logging
 
-from src.utils import DBConnection, setup_logger, safe_merge
+from src.utils import (
+    DBConnection,
+    setup_logger,
+    safe_merge,
+    parse_starting_pitcher_id,
+)
 from src.config import DBConfig, LogConfig
 
 STARTERS_TABLE = "game_level_starting_pitchers"
@@ -32,6 +37,15 @@ def build_matchup_table(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
         boxscores = pd.read_sql_query(f"SELECT * FROM {BOXSCORES_TABLE}", conn)
         if boxscores.empty:
             logger.warning("No rows found in %s", BOXSCORES_TABLE)
+        else:
+            if "away_pitcher_ids" in boxscores.columns:
+                boxscores["away_starting_pitcher_id"] = boxscores[
+                    "away_pitcher_ids"
+                ].apply(parse_starting_pitcher_id)
+            if "home_pitcher_ids" in boxscores.columns:
+                boxscores["home_starting_pitcher_id"] = boxscores[
+                    "home_pitcher_ids"
+                ].apply(parse_starting_pitcher_id)
 
         # Merge starter metrics with opponent batting
         merge_cols = ["game_pk", "pitcher_id", "opponent_team"]
@@ -49,6 +63,12 @@ def build_matchup_table(db_path: Path = DBConfig.PATH) -> pd.DataFrame:
             how="left",
             suffixes=("", "_bx"),
         )
+
+        # Duplicate rows can occur if ``team_batting`` or ``starters`` contain
+        # repeated records for the same pitcher/game. Drop any exact
+        # duplicates to keep one row per starting pitcher appearance.
+        if {"game_pk", "pitcher_id"}.issubset(merged.columns):
+            merged = merged.drop_duplicates(subset=["game_pk", "pitcher_id"]) 
 
         # If the boxscores table also contains a ``game_date`` column, fill any
         # missing values in the starter data and drop the extra column so the

--- a/src/features/contextual.py
+++ b/src/features/contextual.py
@@ -15,6 +15,7 @@ from src.utils import (
     safe_merge,
     load_table_cached,
     deduplicate_columns,
+    deduplicate_index,
 )
 from src.config import (
     DBConfig,
@@ -144,6 +145,7 @@ def _add_group_rolling(
         numeric_cols = [c for c in numeric_cols if c in df.columns and c not in exclude_cols]
 
     df_idx = df.set_index(list(group_cols) + [date_col])
+    df_idx = deduplicate_index(df_idx)
     shifted = df_idx[numeric_cols].groupby(level=group_cols).shift(1)
 
     frames = [df_idx]
@@ -157,8 +159,14 @@ def _add_group_rolling(
         stds = roll.xs("std", level=-1, axis=1)
         means.columns = [f"{prefix}{c}_mean_{window}" for c in numeric_cols]
         stds.columns = [f"{prefix}{c}_std_{window}" for c in numeric_cols]
-        momentum = shifted[numeric_cols] - means
-        momentum.columns = [f"{prefix}{c}_momentum_{window}" for c in numeric_cols]
+        # Subtract using numpy arrays to avoid index alignment issues when
+        # duplicate level names exist in the MultiIndex
+        momentum_values = shifted[numeric_cols].to_numpy() - means.to_numpy()
+        momentum = pd.DataFrame(
+            momentum_values,
+            index=means.index,
+            columns=[f"{prefix}{c}_momentum_{window}" for c in numeric_cols],
+        )
         frames.extend([means, stds, momentum])
 
     if ewm_halflife is not None:
@@ -167,10 +175,14 @@ def _add_group_rolling(
             .apply(lambda x: x.ewm(halflife=ewm_halflife, min_periods=1).mean())
         )
         ewm.columns = [f"{prefix}{c}_ewm_{int(ewm_halflife)}" for c in numeric_cols]
-        momentum_ewm = shifted[numeric_cols] - ewm
-        momentum_ewm.columns = [
-            f"{prefix}{c}_momentum_ewm_{int(ewm_halflife)}" for c in numeric_cols
-        ]
+        momentum_ewm_values = shifted[numeric_cols].to_numpy() - ewm.to_numpy()
+        momentum_ewm = pd.DataFrame(
+            momentum_ewm_values,
+            index=ewm.index,
+            columns=[
+                f"{prefix}{c}_momentum_ewm_{int(ewm_halflife)}" for c in numeric_cols
+            ],
+        )
         frames.extend([ewm, momentum_ewm])
 
     result = pd.concat(frames, axis=1)

--- a/src/features/join.py
+++ b/src/features/join.py
@@ -19,6 +19,8 @@ from .selection import BASE_EXCLUDE_COLS
 EXTRA_CAT_EXCLUDE_COLS = [
     "away_pitcher_ids",
     "home_pitcher_ids",
+    "away_starting_pitcher_id",
+    "home_starting_pitcher_id",
     "scraped_timestamp",
 ]
 import re


### PR DESCRIPTION
## Summary
- make index level names unique with `deduplicate_index`
- apply index deduplication in `_add_group_rolling`
- cover `deduplicate_index` with unit test
- parse starting pitcher id from boxscore lists
- drop starting pitcher id columns when building final features
- drop duplicate pitcher-game rows in matchup table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68532039ac50833185e6af6945d84e8b